### PR TITLE
Add spline programming support (PW, SD, PL block addresses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The **NC-GCode-Interpreter** offers a streamlined and efficient solution for int
 - **Arithmetic Operations**: Supports basic operations such as addition, subtraction, multiplication, and division.
 - **Array Operations**: Manages arrays and allows operations on them.
 - **Incremental Changes**: Facilitates incremental changes in axes positions like `X=IC(2)`.
+- **Spline Programming**: `ASPLINE`, `BSPLINE` and `CSPLINE` blocks with their start/end conditions (`BAUTO`/`BNAT`/`BTAN`, `EAUTO`/`ENAT`/`ETAN`) and the spline block addresses `PW` (point weight), `SD` (spline degree) and `PL` (parameter interval length). Block addresses appear as output columns; unlike axes they receive no `TRANS` offset and are not forward-filled, since e.g. a point weight only applies to the point it is programmed with.
 
 ### Additional Functionality
 

--- a/examples/spline.csv
+++ b/examples/spline.csv
@@ -1,0 +1,19 @@
+gg01_motion,gg19_curve_start_spline,gg20_curve_end_spline,X,Y,F,PW,SD,M,comment
+,,,,,,,,,"; Spline interpolation: ASPLINE / BSPLINE / CSPLINE with PW, SD, PL"
+,,,,,,,,,"; PW (point weight), SD (spline degree) and PL (parameter interval length)"
+,,,,,,,,,; are block addresses: they appear in the output but are not axes
+,,,,,,,,,; (no TRANS offset) and are not forward-filled (a point weight belongs
+,,,,,,,,,; to the point it is programmed with).
+G1,,,0.000,0.000,1000.000,,,,
+G1,,,0.000,0.000,1000.000,,,,"; B spline of degree 2, control points with individual weights"
+BSPLINE,,,0.000,0.000,1000.000,,2.000,,
+BSPLINE,,,10.000,20.000,1000.000,2.000,,,
+BSPLINE,,,30.000,40.000,1000.000,,,,
+BSPLINE,,,50.000,10.000,1000.000,0.500,,,
+BSPLINE,,,60.000,20.000,1000.000,,,,
+BSPLINE,,,60.000,20.000,1000.000,,,,; Akima spline with natural start and tangential end condition
+ASPLINE,BNAT,ETAN,60.000,20.000,1000.000,,,,
+ASPLINE,BNAT,ETAN,70.000,30.000,1000.000,,,,
+ASPLINE,BNAT,ETAN,80.000,0.000,1000.000,,,,
+G1,BNAT,ETAN,90.000,0.000,1000.000,,,,
+G1,BNAT,ETAN,90.000,0.000,1000.000,,,M30,

--- a/examples/spline.mpf
+++ b/examples/spline.mpf
@@ -1,0 +1,22 @@
+; Spline interpolation: ASPLINE / BSPLINE / CSPLINE with PW, SD, PL
+; PW (point weight), SD (spline degree) and PL (parameter interval length)
+; are block addresses: they appear in the output but are not axes
+; (no TRANS offset) and are not forward-filled (a point weight belongs
+; to the point it is programmed with).
+
+G1 X0 Y0 F1000
+
+; B spline of degree 2, control points with individual weights
+BSPLINE SD=2
+X10 Y20 PW=2
+X30 Y40
+X50 Y10 PW=0.5
+X60 Y20
+
+; Akima spline with natural start and tangential end condition
+ASPLINE BNAT ETAN
+X70 Y30
+X80 Y0
+
+G1 X90 Y0
+M30

--- a/python/nc_gcode_interpreter/__init__.py
+++ b/python/nc_gcode_interpreter/__init__.py
@@ -200,6 +200,9 @@ def sanitize_dataframe(
         "RA1", "RA2", "RA3", "RA4", "RA5", "RA6",
     ]
     string_columns = {*modal, *non_modal, "T", "non_returning_function_call", "comment"}
+    # Spline block addresses: value columns, but never forward-filled (a
+    # point weight applies only to the point it is programmed with).
+    block_addresses = ["PW", "SD", "PL"]
 
     # Value columns: anything that is not a known string/list column.
     value_columns = [
@@ -220,7 +223,8 @@ def sanitize_dataframe(
     order: list[str] = []
     for name in (
         ["N"] + modal + non_modal + known_axes
-        + sorted(c for c in value_columns if c not in known_axes)
+        + sorted(c for c in value_columns if c not in known_axes and c not in block_addresses)
+        + block_addresses
         + ["T", "M", "non_returning_function_call", "comment"]
     ):
         if name in df.columns and name not in order:
@@ -229,7 +233,11 @@ def sanitize_dataframe(
 
     # Forward-fill value columns and modal G-group columns.
     if not disable_forward_fill:
-        fill = [c for c in df.columns if c in value_columns or c == "N" or c in modal]
+        fill = [
+            c
+            for c in df.columns
+            if (c in value_columns and c not in block_addresses) or c == "N" or c in modal
+        ]
         df = df.with_columns([pl.col(c).fill_null(strategy="forward") for c in fill])
     return df
 

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -347,6 +347,9 @@ fn interpret_assignment(element: Pair<Rule>, state: &mut State) -> Result<(Strin
 
     if state.is_axis(&key) {
         state.update_axis(&key, local_value)?;
+    } else if state.is_block_address(&key) {
+        // Block addresses (e.g. spline PW/SD/PL) only appear in the output row;
+        // they are neither axes nor user variables, so nothing is stored.
     } else {
         state.symbol_table.insert(key.clone(), local_value);
     }
@@ -906,8 +909,10 @@ fn interpret_statement(
                 if state.is_axis(&key) {
                     // State keeps local coordinates; the output row gets the machine
                     // coordinate under the translation active at this point in the program.
-                    let machine_value = local_value + state.get_translation(&key);
+                    let machine_value = state.get_axis_machine(&key).unwrap_or(local_value);
                     last.insert(key, Value::Float(machine_value));
+                } else if state.is_block_address(&key) {
+                    last.insert(key, Value::Float(local_value));
                 }
             }
             Rule::tool_selection => interpret_tool_selection(statement, output, state)?,

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,6 +7,7 @@
 //! CSV directly with the `csv` crate.
 
 use crate::modal_groups::{MODAL_G_GROUPS, NON_MODAL_G_GROUPS};
+use crate::state::BLOCK_ADDRESSES;
 use crate::types::Value;
 use std::collections::{HashMap, HashSet};
 
@@ -115,12 +116,17 @@ impl Table {
             .copied()
             .filter(|name| {
                 !ordered.iter().any(|c| c == name)
+                    && !BLOCK_ADDRESSES.contains(name)
                     && !matches!(*name, "T" | "M" | "non_returning_function_call" | "comment")
             })
             .collect();
         extra.sort_unstable();
         for name in extra {
             ordered.push(name.to_string());
+        }
+        // Block addresses (spline PW/SD/PL) come after the axes.
+        for &name in BLOCK_ADDRESSES {
+            push_if_present(name, &mut ordered);
         }
         for name in ["T", "M", "non_returning_function_call", "comment"] {
             push_if_present(name, &mut ordered);
@@ -134,7 +140,10 @@ impl Table {
         let mut columns: Vec<(String, Column)> = Vec::with_capacity(ordered.len());
         for name in ordered {
             let mut column = build_column(&name, &rows);
-            let is_value_column = matches!(column, Column::Float(_) | Column::Int(_));
+            // Block addresses (spline PW/SD/PL) are never forward-filled: a
+            // point weight applies only to the point it is programmed with.
+            let is_value_column = matches!(column, Column::Float(_) | Column::Int(_))
+                && !BLOCK_ADDRESSES.contains(&name.as_str());
             if !disable_forward_fill && (is_value_column || modal.contains(name.as_str())) {
                 column.forward_fill();
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,12 @@
 use crate::errors::ParsingError;
 use std::collections::HashMap;
 
+/// Block addresses: per-block values that are emitted to the output like axes,
+/// but are not axes (no translation applies) and not user variables.
+/// Currently the spline programming addresses (PW: point weight, SD: spline
+/// degree, PL: parameter interval length).
+pub const BLOCK_ADDRESSES: &[&str] = &["PW", "SD", "PL"];
+
 #[derive(Debug, Clone)]
 pub struct State {
     pub axes: HashMap<String, f32>,
@@ -85,6 +91,11 @@ impl State {
     /// Checks if a given key is a valid axis identifier
     pub fn is_axis(&self, key: &str) -> bool {
         self.axis_identifiers.contains(&key.to_uppercase())
+    }
+
+    /// Checks if a given key is a block address (e.g. spline PW/SD/PL)
+    pub fn is_block_address(&self, key: &str) -> bool {
+        BLOCK_ADDRESSES.contains(&key.to_uppercase().as_str())
     }
 
     /// Updates the translation value for an axis


### PR DESCRIPTION
Now a single-concern PR (was: spline + translation + perf + packaging; those live in #24, #25, #26 below it in the stack).

## What

`ASPLINE`/`BSPLINE`/`CSPLINE` and the spline start/end conditions (`BAUTO`/`BNAT`/`BTAN`, `EAUTO`/`ENAT`/`ETAN`) already parsed as G-groups, but the spline block addresses were silently swallowed into the variable table. New block-address concept: **`PW` (point weight), `SD` (spline degree), `PL` (parameter interval length)** are emitted as `Float64` output columns.

Unlike axes they receive no `TRANS` offset and are **not forward-filled** — a point weight applies only to the point it is programmed with (NC Programming Manual §4.7.2). Example output for `examples/spline.mpf`:

```
gg01_motion,X,Y,F,PW,SD
BSPLINE,0.000,0.000,1000.000,,2.000
BSPLINE,10.000,20.000,1000.000,2.000,
BSPLINE,30.000,40.000,1000.000,,
BSPLINE,50.000,10.000,1000.000,0.500,
```

Note: `PW`/`SD`/`PL` become reserved words; `DEF REAL PW` is rejected later in the stack (#20) rather than silently shadowing the column.

**Stack: #24 (deps/packaging) → #25 (parser perf) → #26 (translation fix) → this → #19 → #20 → #23.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)