### PR TITLE
Reject unsupported statements loudly instead of corrupting output

### DIFF
--- a/examples/trans_reset.csv
+++ b/examples/trans_reset.csv
@@ -1,5 +1,11 @@
-X,comment
-,; Bare TRANS deletes the programmable frame (translation resets to zero)
-1.000,
-102.000,
-3.000,
+X,Y,comment
+,,; TRANS is a substituting frame instruction (manual 3.12.2.2):
+,,"; every TRANS deletes ALL previously programmed offsets, including on"
+,,; axes not mentioned in the block. A bare absolute frame instruction
+,,"; (TRANS, ROT, SCALE, MIRROR) deletes the whole programmable frame."
+1.000,1.000,
+102.000,22.000,
+13.000,3.000,"; X offset replaced (13), Y offset deleted (3)"
+4.000,4.000,"; bare TRANS: no offsets (4, 4)"
+55.000,5.000,"; additive on empty frame (55, 5)"
+6.000,6.000,"; bare absolute ROT deletes the frame too (6, 6)"

--- a/examples/trans_reset.csv
+++ b/examples/trans_reset.csv
@@ -1,0 +1,5 @@
+X,comment
+,; Bare TRANS deletes the programmable frame (translation resets to zero)
+1.000,
+102.000,
+3.000,

--- a/examples/trans_reset.mpf
+++ b/examples/trans_reset.mpf
@@ -1,6 +1,15 @@
-; Bare TRANS deletes the programmable frame (translation resets to zero)
-X1
-TRANS X100
-X2
+; TRANS is a substituting frame instruction (manual 3.12.2.2):
+; every TRANS deletes ALL previously programmed offsets, including on
+; axes not mentioned in the block. A bare absolute frame instruction
+; (TRANS, ROT, SCALE, MIRROR) deletes the whole programmable frame.
+X1 Y1
+TRANS X100 Y20
+X2 Y2
+TRANS X10
+X3 Y3 ; X offset replaced (13), Y offset deleted (3)
 TRANS
-X3
+X4 Y4 ; bare TRANS: no offsets (4, 4)
+ATRANS X50
+X5 Y5 ; additive on empty frame (55, 5)
+ROT
+X6 Y6 ; bare absolute ROT deletes the frame too (6, 6)

--- a/examples/trans_reset.mpf
+++ b/examples/trans_reset.mpf
@@ -1,0 +1,6 @@
+; Bare TRANS deletes the programmable frame (translation resets to zero)
+X1
+TRANS X100
+X2
+TRANS
+X3

--- a/python/tests/test_unsupported.py
+++ b/python/tests/test_unsupported.py
@@ -1,0 +1,55 @@
+import pytest
+from nc_gcode_interpreter import nc_to_dataframe
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "GOTOF MYLABEL\nX2",  # jump forward to a label
+        "GOTOF 20\nX2",  # jump forward to a block number
+        "GOTOB START\nX2",  # jump backward
+        "GOTO END1\nX2",  # jump
+        "GOTOC TARGET\nX2",  # jump without alarm
+        "LOOP\nX1\nENDLOOP",  # endless loop, can only be left with a jump
+        "MIRROR X0\nX2",  # mirroring frame
+        "AMIRROR X0\nX2",  # additive mirroring frame
+        "ROT RPL=30\nX2",  # rotation frame
+        "AROT RPL=30\nX2",  # additive rotation frame
+        "SCALE X2 Y2\nX2",  # scaling frame
+        "ASCALE X2 Y2\nX2",  # additive scaling frame
+    ],
+    ids=lambda p: p.splitlines()[0],
+)
+def test_unsupported_statements_error_loudly(program):
+    """
+    Statements that would silently corrupt the output (skipped jumps,
+    unmodeled frame transformations) must raise instead of being ignored.
+    """
+    with pytest.raises(ValueError, match="not supported"):
+        nc_to_dataframe(program)
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "ROT\nX2",  # bare substituting frame instruction: resets a frame
+        "MIRROR\nX2",  # component this interpreter never sets -> safe no-op
+        "SCALE\nX2",
+    ],
+    ids=lambda p: p.splitlines()[0],
+)
+def test_bare_frame_reset_is_noop(program):
+    df, _state = nc_to_dataframe(program)
+    assert df["X"][-1] == 2.0
+
+
+def test_bare_trans_resets_translation():
+    df, _state = nc_to_dataframe("X1\nTRANS X100\nX2\nTRANS\nX3")
+    assert df["X"].to_list() == [1.0, 102.0, 3.0]
+
+
+def test_keyword_prefix_is_not_a_frame_instruction():
+    """An identifier that merely starts with a frame keyword (e.g. a
+    subprogram called TRANSFORM) must still parse as a function call."""
+    df, _state = nc_to_dataframe("TRANSFORM(1)\nX2")
+    assert df["non_returning_function_call"][0] == "TRANSFORM(1)"

--- a/python/tests/test_unsupported.py
+++ b/python/tests/test_unsupported.py
@@ -32,8 +32,8 @@ def test_unsupported_statements_error_loudly(program):
 @pytest.mark.parametrize(
     "program",
     [
-        "ROT\nX2",  # bare substituting frame instruction: resets a frame
-        "MIRROR\nX2",  # component this interpreter never sets -> safe no-op
+        "ROT\nX2",  # bare absolute frame instruction on an empty frame
+        "MIRROR\nX2",
         "SCALE\nX2",
     ],
     ids=lambda p: p.splitlines()[0],
@@ -46,6 +46,67 @@ def test_bare_frame_reset_is_noop(program):
 def test_bare_trans_resets_translation():
     df, _state = nc_to_dataframe("X1\nTRANS X100\nX2\nTRANS\nX3")
     assert df["X"].to_list() == [1.0, 102.0, 3.0]
+
+
+def test_trans_is_substituting():
+    """TRANS deletes ALL previously programmed offsets, including on axes
+    not mentioned in the block (manual 3.12.2.2)."""
+    df, _state = nc_to_dataframe("TRANS X10\nX0 Y0\nTRANS Y5\nX0 Y0")
+    assert df["X"].to_list() == [10.0, 0.0]
+    assert df["Y"].to_list() == [0.0, 5.0]
+
+
+def test_bare_absolute_frame_instruction_deletes_frame():
+    """A bare ROT/SCALE/MIRROR deletes the whole programmable frame,
+    including a previously set TRANS offset (manual 3.12.2.1)."""
+    df, _state = nc_to_dataframe("TRANS X100\nX2\nROT\nX3")
+    assert df["X"].to_list() == [102.0, 3.0]
+
+
+def test_frame_instruction_mid_block_errors():
+    """Frame instructions must be alone in the block; `G1 MIRROR X0` must
+    not be interpreted as a G-command plus an axis move to X=0."""
+    with pytest.raises(ValueError, match="not supported"):
+        nc_to_dataframe("G1 MIRROR X0")
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "DEF REAL PW\nX1",  # bare definition
+        "DEF REAL PW=1\nX1",  # definition with initialization
+    ],
+    ids=lambda p: p.splitlines()[0],
+)
+def test_def_of_block_address_errors(program):
+    """PW/SD/PL are reserved block addresses; defining a variable with one
+    of these names would silently shadow the output column."""
+    with pytest.raises(ValueError, match="reserved block address"):
+        nc_to_dataframe(program)
+
+
+def test_lowercase_block_address_is_normalized():
+    """Lowercase pw=2 must land in the PW column (and stay excluded from
+    forward-fill), not create a separate lowercase column."""
+    df, _state = nc_to_dataframe("BSPLINE\nX=5 pw=2\nX=6")
+    assert df["PW"].to_list()[-2:] == [2.0, None]
+    assert "pw" not in df.columns
+
+
+@pytest.mark.parametrize(
+    "program, variable, expected",
+    [
+        ("DEF REAL TRANS_X = 5\nX=TRANS_X", "TRANS_X", 5.0),
+        ("DEF REAL GOTOFFSET = 7\nX=GOTOFFSET", "GOTOFFSET", 7.0),
+    ],
+    ids=["TRANS_X", "GOTOFFSET"],
+)
+def test_keyword_prefixed_identifiers_still_parse(program, variable, expected):
+    """Identifiers that merely start with a frame or GOTO keyword must
+    still parse as ordinary variable names."""
+    df, state = nc_to_dataframe(program)
+    assert state["symbol_table"][variable] == expected
+    assert df["X"][-1] == expected
 
 
 def test_keyword_prefix_is_not_a_frame_instruction():

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -86,6 +86,8 @@ To fix this, ensure that each block contains at most one M command.
     UnexpectedAxis { axis: String, axes: String },
     #[error("Cannot define a variable named '{name}', as it conflicts with an axis name")]
     AxisUsedAsVariable { name: String },
+    #[error("Cannot define a variable named '{name}', as it is a reserved block address (spline PW/SD/PL)")]
+    ReservedNameUsedAsVariable { name: String },
     #[error(r#"
 Missing axis mapping on line {line_no}
 ----------------------------------------

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -112,6 +112,20 @@ Array indices must be non-negative and within the valid range."#)]
         index: usize,
     },
     #[error(r#"
+Unsupported statement on line {line_no}
+----------------------------------------
+Line: {preview}
+
+Details: {statement} is not supported by this interpreter.
+{hint}
+"#)]
+    UnsupportedStatement {
+        line_no: usize,
+        preview: String,
+        statement: String,
+        hint: String,
+    },
+    #[error(r#"
 Invalid function call on line {line_no}
 ----------------------------------------
 Line: {preview}

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -7,26 +7,29 @@ comment             =  { ";" ~ (!newline ~ ANY)* }
 block               =  { block_number_set? ~ (definition | frame_op | control | statement*) ~ comment? }
 block_number_set    = _{ "N" ~ block_number }
 control             =  {
-    goto_statement
-  | gotob_statement
+    gotoc_statement
   | gotof_statement
-  | gotoc_statement
+  | gotob_statement
+  | goto_statement
   | if_statement
   | loop_statement
   | for_statement
   | while_statement
   | repeat_until_statement
 }
-goto_statement         =  { ^"GOTO" ~ label }
-gotob_statement        =  { ^"GOTOB" ~ block_number }
-gotof_statement        =  { ^"GOTOF" ~ block_number }
-gotoc_statement        =  { ^"GOTOC" ~ condition ~ newline ~ label }
+// GOTO targets are labels or block numbers. These statements are recognized
+// so the interpreter can reject them loudly; silently skipping a jump would
+// produce wrong coordinates.
+goto_statement         =  { ^"GOTO" ~ goto_target }
+gotob_statement        =  { ^"GOTOB" ~ goto_target }
+gotof_statement        =  { ^"GOTOF" ~ goto_target }
+gotoc_statement        =  { ^"GOTOC" ~ goto_target }
+goto_target            =  { identifier | block_number }
 if_statement           =  { ^"IF" ~ condition ~ comment? ~ newline ~ blocks ~ (^"ELSE" ~ blocks)? ~ ^"ENDIF" }
 loop_statement         =  { ^"LOOP" ~ blocks ~ ^"ENDLOOP" }
 for_statement          =  { ^"FOR" ~ assignment ~ ^"TO" ~ expression ~ blocks ~ ^"ENDFOR" }
 while_statement        =  { ^"WHILE" ~ condition ~ blocks ~ ^"ENDWHILE" }
 repeat_until_statement =  { ^"REPEAT" ~ blocks ~ ^"UNTIL" ~ condition }
-label                  =  { ^"LABEL" ~ identifier }
 block_number           =  { integer }
 condition              =  { base_condition | ("(" ~ base_condition ~ ")") }
 base_condition         = _{ (expression ~ relational_operator ~ expression) | expression }
@@ -64,6 +67,7 @@ reserved   = _{
   | ^"UNTIL"
   | ^"ENDWHILE"
   | ^"ENDFOR"
+  | ^"ENDLOOP"
 }
 
 identifier = @{
@@ -117,12 +121,14 @@ arith_fun_name   = { "SIN" | "COS" | "TAN" | "ASIN" | "ACOS" | "ATAN2" | "SQRT" 
 
 tool_selection = { ^"T" ~ "=" ~ quoted_string }
 
-// frame instructions
-frame_op     = { frame_trans | frame_scale | frame_atrans | frame_ascale }
-frame_trans  = { ^"TRANS" ~ assignment+ }
-frame_scale  = { ^"SCALE" ~ assignment+ }
-frame_atrans = { ^"ATRANS" ~ assignment+ }
-frame_ascale = { ^"ASCALE" ~ assignment+ }
+// Frame instructions. A single rule captures the whole family (with any
+// number of axis assignments, including none: a bare substituting frame
+// instruction like `TRANS` resets the frame component). The keyword is
+// atomic so that identifiers such as TRANSFORM cannot half-match.
+frame_op = { frame_kw ~ assignment* }
+frame_kw = @{
+    (^"AMIRROR" | ^"AROTS" | ^"AROT" | ^"ASCALE" | ^"ATRANS" | ^"CROTS" | ^"MIRROR" | ^"ROTS" | ^"ROT" | ^"SCALE" | ^"TRANS") ~ !ASCII_ALPHANUMERIC
+}
 
 // function call parser
 non_returning_function_call =  { identifier ~ ("(" ~ function_arguments? ~ ")")? }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -7,10 +7,7 @@ comment             =  { ";" ~ (!newline ~ ANY)* }
 block               =  { block_number_set? ~ (definition | frame_op | control | statement*) ~ comment? }
 block_number_set    = _{ "N" ~ block_number }
 control             =  {
-    gotoc_statement
-  | gotof_statement
-  | gotob_statement
-  | goto_statement
+    goto_statement
   | if_statement
   | loop_statement
   | for_statement
@@ -19,11 +16,10 @@ control             =  {
 }
 // GOTO targets are labels or block numbers. These statements are recognized
 // so the interpreter can reject them loudly; silently skipping a jump would
-// produce wrong coordinates.
-goto_statement         =  { ^"GOTO" ~ goto_target }
-gotob_statement        =  { ^"GOTOB" ~ goto_target }
-gotof_statement        =  { ^"GOTOF" ~ goto_target }
-gotoc_statement        =  { ^"GOTOC" ~ goto_target }
+// produce wrong coordinates. The keyword is atomic with a word boundary so
+// that identifiers like GOTOFFSET still parse as ordinary names.
+goto_statement         =  { goto_kw ~ goto_target }
+goto_kw                = @{ (^"GOTOC" | ^"GOTOF" | ^"GOTOB" | ^"GOTO") ~ !(ASCII_ALPHANUMERIC | "_") }
 goto_target            =  { identifier | block_number }
 if_statement           =  { ^"IF" ~ condition ~ comment? ~ newline ~ blocks ~ (^"ELSE" ~ blocks)? ~ ^"ENDIF" }
 loop_statement         =  { ^"LOOP" ~ blocks ~ ^"ENDLOOP" }
@@ -127,7 +123,7 @@ tool_selection = { ^"T" ~ "=" ~ quoted_string }
 // atomic so that identifiers such as TRANSFORM cannot half-match.
 frame_op = { frame_kw ~ assignment* }
 frame_kw = @{
-    (^"AMIRROR" | ^"AROTS" | ^"AROT" | ^"ASCALE" | ^"ATRANS" | ^"CROTS" | ^"MIRROR" | ^"ROTS" | ^"ROT" | ^"SCALE" | ^"TRANS") ~ !ASCII_ALPHANUMERIC
+    (^"AMIRROR" | ^"AROTS" | ^"AROT" | ^"ASCALE" | ^"ATRANS" | ^"CROTS" | ^"MIRROR" | ^"ROTS" | ^"ROT" | ^"SCALE" | ^"TRANS") ~ !(ASCII_ALPHANUMERIC | "_")
 }
 
 // function call parser

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -862,16 +862,39 @@ fn interpret_control(
     let mut pairs = element.into_inner();
     let pair = pairs.next().expect("Expected a pair, got none");
     match pair.as_rule() {
-        // Rule::goto_statement => println!("Goto statement: {:?}", pair),
-        // Rule::gotob_statement => println!("Gotob statement: {:?}", pair),
-        // Rule::gotof_statement => println!("Gotof statement: {:?}", pair),
-        // Rule::gotoc_statement => println!("Gotoc statement: {:?}", pair),
         Rule::if_statement => interpret_statement_if(pair, output, state),
-        // Rule::loop_statement => println!("Loop statement: {:?}", pair),
         Rule::for_statement => interpret_statement_for(pair, output, state),
         Rule::while_statement => interpret_statement_while(pair, output, state),
         Rule::repeat_until_statement => interpret_statement_repeat_until(pair, output, state),
-        _ => panic!("Unexpected rule: {:?}", pair.as_rule()),
+        Rule::goto_statement | Rule::gotob_statement | Rule::gotof_statement | Rule::gotoc_statement => {
+            let (line_no, preview) = get_error_context(&pair, state);
+            let keyword = pair.as_str().split_whitespace().next().unwrap_or("GOTO").to_uppercase();
+            Err(ParsingError::UnsupportedStatement {
+                line_no,
+                preview,
+                statement: format!("The jump statement {}", keyword),
+                hint: "Jumps are not interpreted; silently skipping one would produce wrong \
+                       coordinates. Restructure the program with IF/WHILE/FOR/REPEAT instead."
+                    .to_string(),
+            })
+        }
+        Rule::loop_statement => {
+            let (line_no, preview) = get_error_context(&pair, state);
+            Err(ParsingError::UnsupportedStatement {
+                line_no,
+                preview,
+                statement: "The endless loop LOOP ... ENDLOOP".to_string(),
+                hint: "LOOP can only be left with a jump, which is not interpreted. Use \
+                       WHILE/FOR/REPEAT with an explicit condition instead."
+                    .to_string(),
+            })
+        }
+        _ => Err(annotate_error(
+            &pair,
+            "control statement",
+            format!("Unexpected rule in interpret_control: {:?}", pair.as_rule()),
+            state,
+        )),
     }
 }
 fn insert_m_key(last: &mut HashMap<String, Value>, value: &str, line_no: usize, preview: String) -> Result<(), ParsingError> {
@@ -963,58 +986,76 @@ fn interpret_statement(
     }
     Ok(())
 }
+/// Evaluate the assignments of a frame instruction without moving any axis:
+/// the axis state is saved and restored around parsing, and each assignment
+/// must target a valid axis.
+fn frame_assignments(
+    pairs: Vec<Pair<Rule>>,
+    state: &mut State,
+) -> Result<Vec<(String, f32)>, ParsingError> {
+    let mut result = Vec::with_capacity(pairs.len());
+    for pair in pairs {
+        let saved_axes = state.axes.clone();
+        let (key, value) = interpret_assignment(pair, state)?;
+        // Undo the axis-position side effect of interpret_assignment
+        state.axes = saved_axes;
+
+        if !state.is_axis(&key) {
+            return Err(ParsingError::UnexpectedAxis {
+                axis: key,
+                axes: state.axis_identifiers.join(", "),
+            });
+        }
+        result.push((key, value));
+    }
+    Ok(result)
+}
+
 fn interpret_frame_op(element: Pair<Rule>, state: &mut State) -> Result<(), ParsingError> {
+    let (line_no, preview) = get_error_context(&element, state);
     let mut pairs = element.into_inner();
-    let pair = pairs.next().expect("Expected a pair, got none");
-    match pair.as_rule() {
-        Rule::frame_trans => {
-            for pair in pair.into_inner() {
-                // We need to parse the assignment to get the key and value,
-                // but we don't want to update the axis position.
-                // Save the current axis state, call interpret_assignment, then restore it.
-                let saved_axes = state.axes.clone();
-                let (key, value) = interpret_assignment(pair, state)?;
-                // Restore the axis values (undo the side effect of interpret_assignment)
-                state.axes = saved_axes;
+    let kw = pairs.next().expect("frame_op must start with a frame keyword");
+    let op = kw.as_str().to_uppercase();
+    let assignments: Vec<Pair<Rule>> = pairs.collect();
 
-                if state.is_axis(&key) {
+    match op.as_str() {
+        "TRANS" => {
+            if assignments.is_empty() {
+                // Bare TRANS deletes the programmable frame
+                state.reset_translations();
+            } else {
+                for (key, value) in frame_assignments(assignments, state)? {
                     state.update_translation(&key, value)?;
-                } else {
-                    return Err(ParsingError::UnexpectedAxis {
-                        axis: key,
-                        axes: state.axes.keys().cloned().collect(),
-                    });
                 }
             }
             Ok(())
         }
-        Rule::frame_atrans => {
-            for pair in pair.into_inner() {
-                // Same as TRANS - save and restore axis state
-                let saved_axes = state.axes.clone();
-                let (key, value) = interpret_assignment(pair, state)?;
-                state.axes = saved_axes;
-
-                if state.is_axis(&key) {
-                    let current_translation = state.get_translation(&key);
-                    state.update_translation(&key, current_translation + value)?;
-                } else {
-                    return Err(ParsingError::UnexpectedAxis {
-                        axis: key,
-                        axes: state.axes.keys().cloned().collect(),
-                    });
-                }
+        "ATRANS" => {
+            for (key, value) in frame_assignments(assignments, state)? {
+                let current_translation = state.get_translation(&key);
+                state.update_translation(&key, current_translation + value)?;
             }
             Ok(())
         }
+        // Rotation, scaling and mirroring change the geometry in ways this
+        // interpreter does not model. A bare (substituting) instruction only
+        // resets a frame component that can never have been set, so it is a
+        // safe no-op; anything with parameters must fail loudly instead of
+        // producing wrong coordinates.
         _ => {
-            return Err(ParsingError::UnexpectedRule {
-                rule: pair.as_rule(),
-                context: "interpret_frame_op".to_string(),
-                line_no: pair.line_col().0,
-                preview: state.get_line(pair.line_col().0).unwrap_or("").to_string(),
-                message: format!("Unexpected rule in interpret_frame_op: {:?}", pair.as_rule()),
-            })
+            if assignments.is_empty() {
+                Ok(())
+            } else {
+                Err(ParsingError::UnsupportedStatement {
+                    line_no,
+                    preview,
+                    statement: format!("The frame instruction {}", op),
+                    hint: "Rotation, scaling and mirroring frames are not modeled; interpreting \
+                           this program would produce wrong coordinates. Only TRANS and ATRANS \
+                           are supported."
+                        .to_string(),
+                })
+            }
         }
     }
 }

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -6,6 +6,14 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 type Output = Vec<HashMap<String, Value>>;
+
+/// The frame instruction family, normally captured by the frame_op grammar
+/// rule at block start. Also present in G-group 3, where they can only be
+/// reached when they FOLLOW another statement in the block - which is invalid
+/// (frame instructions must be alone in the block) and rejected loudly.
+const FRAME_KEYWORDS: &[&str] = &[
+    "TRANS", "ATRANS", "SCALE", "ASCALE", "ROT", "AROT", "ROTS", "AROTS", "CROTS", "MIRROR", "AMIRROR",
+];
 fn interpret_primary(primary: Pair<Rule>, state: &mut State) -> Result<f32, ParsingError> {
     let inner_pair = primary.into_inner().next().expect("Error");
     match inner_pair.as_rule() {
@@ -333,6 +341,18 @@ fn interpret_non_returning_function_call(function_call: Pair<Rule>) -> (String, 
     ("non_returning_function_call".to_string(), command_str)
 }
 
+/// Axis and block-address names are case-insensitive; normalize them to
+/// uppercase so state lookups and output columns are consistent regardless
+/// of the case used in the program (`x10` must hit the same axis, column and
+/// translation as `X10`).
+fn normalize_reserved_case(key: String, state: &State) -> String {
+    if state.is_axis(&key) || state.is_block_address(&key) {
+        key.to_uppercase()
+    } else {
+        key
+    }
+}
+
 fn interpret_assignment(element: Pair<Rule>, state: &mut State) -> Result<(String, f32), ParsingError> {
     let mut inner_pairs = element.into_inner();
 
@@ -356,12 +376,12 @@ fn interpret_assignment(element: Pair<Rule>, state: &mut State) -> Result<(Strin
             (key, value)
         }
         (Rule::variable, Rule::axis_increment) => {
-            let key = interpret_variable(variable_pair.clone(), state)?;
+            let key = normalize_reserved_case(interpret_variable(variable_pair.clone(), state)?, state);
             let value = interpret_axis_increment(expression_pair, state, key.clone())?;
             (key, value)
         }
         (Rule::variable, Rule::expression) => {
-            let key = interpret_variable(variable_pair.clone(), state)?;
+            let key = normalize_reserved_case(interpret_variable(variable_pair.clone(), state)?, state);
             let value = evaluate_expression(expression_pair, state)?;
             (key, value)
         }
@@ -396,6 +416,11 @@ fn interpret_axis_increment(pair: Pair<Rule>, state: &mut State, key: String) ->
     // axis_increment = { "IC" ~ "(" ~ expression ~ ")" }
     // Returns the new LOCAL coordinate. Since axes now store local coordinates,
     // we simply add the increment to the current local value.
+    // Note: when the frame changed since the previous move, the machine-space
+    // delta is increment + frame change. This matches the control's factory
+    // default SD42440 $SC_FRAME_OFFSET_INCR_PROG = TRUE ("changes to work
+    // offsets are traversed after a frame change"); machines configured with
+    // FALSE traverse the pure increment instead, which is not modeled here.
     let pair_clone = pair.clone();
     let inner_pair = pair.into_inner().next().expect("Expected an expression inside axis_increment, found none");
     if inner_pair.as_rule() != Rule::expression {
@@ -588,7 +613,9 @@ fn interpret_definition(element: Pair<Rule>, state: &mut State) -> Result<(), Pa
             Rule::assignment => {
                 let res = interpret_assignment(pair, state)?;
                 if state.is_axis(res.0.as_str()) {
-                    Err(ParsingError::AxisUsedAsVariable { name: res.0 })?;
+                    return Err(ParsingError::AxisUsedAsVariable { name: res.0 });
+                } else if state.is_block_address(res.0.as_str()) {
+                    return Err(ParsingError::ReservedNameUsedAsVariable { name: res.0 });
                 }
             }
             Rule::assignment_multi => {
@@ -596,6 +623,11 @@ fn interpret_definition(element: Pair<Rule>, state: &mut State) -> Result<(), Pa
             }
             Rule::variable => {
                 let key = interpret_variable(pair, state)?;
+                if state.is_axis(&key) {
+                    return Err(ParsingError::AxisUsedAsVariable { name: key });
+                } else if state.is_block_address(&key) {
+                    return Err(ParsingError::ReservedNameUsedAsVariable { name: key });
+                }
                 state.symbol_table.insert(key, 0.0);
             }
             Rule::variable_array => {
@@ -866,7 +898,7 @@ fn interpret_control(
         Rule::for_statement => interpret_statement_for(pair, output, state),
         Rule::while_statement => interpret_statement_while(pair, output, state),
         Rule::repeat_until_statement => interpret_statement_repeat_until(pair, output, state),
-        Rule::goto_statement | Rule::gotob_statement | Rule::gotof_statement | Rule::gotoc_statement => {
+        Rule::goto_statement => {
             let (line_no, preview) = get_error_context(&pair, state);
             let keyword = pair.as_str().split_whitespace().next().unwrap_or("GOTO").to_uppercase();
             Err(ParsingError::UnsupportedStatement {
@@ -949,7 +981,22 @@ fn interpret_statement(
                 last.insert(key, Value::Str(value));
             }
             Rule::g_command => {
+                let (line_no, preview) = get_error_context(&statement, state);
                 let (key, value) = interpret_g_command(statement);
+                // Frame instructions are only interpreted as frame_op at the
+                // start of a block ("alone in the block" per manual 3.12.2.1).
+                // If one shows up here it followed another statement, and
+                // e.g. `G1 MIRROR X0` would silently move X to 0. Error loudly.
+                if FRAME_KEYWORDS.contains(&value.to_uppercase().as_str()) {
+                    return Err(ParsingError::UnsupportedStatement {
+                        line_no,
+                        preview,
+                        statement: format!("The frame instruction {} after another statement", value),
+                        hint: "Frame instructions must be programmed in a separate NC block \
+                               (manual 3.12.2.1)."
+                            .to_string(),
+                    });
+                }
                 last.insert(key, Value::Str(value));
             }
             Rule::g_command_numbered => {
@@ -1020,13 +1067,14 @@ fn interpret_frame_op(element: Pair<Rule>, state: &mut State) -> Result<(), Pars
 
     match op.as_str() {
         "TRANS" => {
-            if assignments.is_empty() {
-                // Bare TRANS deletes the programmable frame
-                state.reset_translations();
-            } else {
-                for (key, value) in frame_assignments(assignments, state)? {
-                    state.update_translation(&key, value)?;
-                }
+            // TRANS is a substituting frame instruction: it deletes ALL
+            // previously programmed frame components, including offsets on
+            // axes not mentioned in this block (manual 3.12.2.2, and the
+            // Notice "Absolute frame instructions delete all programmed
+            // frames"). Bare TRANS is therefore just the reset.
+            state.reset_translations();
+            for (key, value) in frame_assignments(assignments, state)? {
+                state.update_translation(&key, value)?;
             }
             Ok(())
         }
@@ -1038,12 +1086,19 @@ fn interpret_frame_op(element: Pair<Rule>, state: &mut State) -> Result<(), Pars
             Ok(())
         }
         // Rotation, scaling and mirroring change the geometry in ways this
-        // interpreter does not model. A bare (substituting) instruction only
-        // resets a frame component that can never have been set, so it is a
-        // safe no-op; anything with parameters must fail loudly instead of
-        // producing wrong coordinates.
+        // interpreter does not model, so anything with parameters must fail
+        // loudly instead of producing wrong coordinates. The bare forms are
+        // frame resets: a bare ABSOLUTE instruction (ROT/ROTS/CROTS/SCALE/
+        // MIRROR) deletes the whole programmable frame including the
+        // translation (manual 3.12.2.1), while a bare ADDITIVE instruction
+        // adds nothing and is a no-op.
         _ => {
             if assignments.is_empty() {
+                if !op.starts_with('A') {
+                    // Bare absolute frame instruction: delete the programmable
+                    // frame. (CROTS is absolute despite the leading C.)
+                    state.reset_translations();
+                }
                 Ok(())
             } else {
                 Err(ParsingError::UnsupportedStatement {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -39,10 +39,9 @@ pub fn nc_to_table(
         allow_undefined_variables,
     );
     if let Some(initial_state) = initial_state {
-        if let Err(error) = interpret_file(initial_state, &mut state) {
-            eprintln!("Error while parsing defaults: {:?}", error);
-            std::process::exit(1);
-        }
+        // Propagate the error instead of exiting: this is library code, and
+        // process::exit would kill e.g. a host Python interpreter.
+        interpret_file(initial_state, &mut state)?;
     }
 
     // Now interpret the main input using the axis_index_map from state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ mod python_bindings {
             axis_index_map,
             allow_undefined_variables,
         )
-        .map_err(|e| PyErr::new::<PyValueError, _>(format!("Error creating DataFrame: {:?}", e)))?;
+        .map_err(|e| PyErr::new::<PyValueError, _>(format!("{}", e)))?;
 
         let data = PyDict::new(py);
         let mut schema: Vec<(String, String)> = Vec::with_capacity(table.columns.len());

--- a/src/state.rs
+++ b/src/state.rs
@@ -116,6 +116,14 @@ impl State {
         *self.translation.get(axis).unwrap_or(&0.0)
     }
 
+    /// Resets all translation values to zero (bare `TRANS` deletes the
+    /// programmable frame)
+    pub fn reset_translations(&mut self) {
+        for value in self.translation.values_mut() {
+            *value = 0.0;
+        }
+    }
+
     /// Updates an axis value in local coordinates (without translation).
     /// Returns the machine coordinate (local + translation) for output purposes.
     pub fn update_axis(&mut self, key: &str, local_value: f32) -> Result<f32, ParsingError> {


### PR DESCRIPTION
Stacked on #19 (which is stacked on #18) — retarget to `main` as the stack merges.

## Problem

For a tool whose purpose is trustworthy interpretation, silently wrong output is worse than an error. Several statement families were silently mis-handled:

| Input | Old behavior |
| --- | --- |
| `GOTOF MYLABEL` | parsed as a *function call*; jump silently skipped, execution continues linearly |
| `GOTOF 20` | `panic!` (crash, not an error) |
| `MIRROR X0` | parsed as G-command + **axis move to X=0** |
| `ROT RPL=30` | rotation ignored; `RPL` stored as an ordinary variable |
| `LOOP … ENDLOOP` | mis-parse (`ENDLOOP` missing from reserved words) → confusing pest error |
| bare `TRANS` | translation **not** reset (manual: deletes the programmable frame) |

## Changes

- **GOTO family** (`GOTO`/`GOTOB`/`GOTOF`/`GOTOC`): grammar now accepts label and block-number targets, and the interpreter raises a dedicated `UnsupportedStatement` error with line context and a restructuring hint. Same for `LOOP`/`ENDLOOP` (an endless loop can only be left with a jump).
- **Frame instruction family** unified into one grammar rule (`frame_kw ~ assignment*`) with an atomic keyword + word-boundary guard, so e.g. a subprogram named `TRANSFORM` still parses as a call:
  - `TRANS`/`ATRANS` with axes: unchanged
  - bare `TRANS`: now resets the programmable offset (manual §3.12.2.2), with a golden example (`trans_reset.mpf`: 1 → 102 → 3)
  - bare `ROT`/`SCALE`/`MIRROR`: safe no-ops (they reset frame components this interpreter never sets)
  - parameterized `ROT`/`AROT`/`ROTS`/`AROTS`/`CROTS`/`SCALE`/`ASCALE`/`MIRROR`/`AMIRROR`: hard error — these change geometry in ways the interpreter does not model
- The `panic!` catch-all in `interpret_control` is gone; unexpected rules become proper errors.
- **Python bindings now surface the Display form of errors** (the formatted, line-annotated messages) instead of the raw Debug struct dump.

## Testing

- New `python/tests/test_unsupported.py`: 16 cases covering every loud-error path, the bare-frame no-ops, the bare-`TRANS` reset, and the `TRANSFORM`-prefix regression.
- `pytest python/tests`: **67 passed, 1 skipped**. Full `examples/*.mpf` CLI sweep: no tracked golden changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Post-review fixes** (commit `fbcbcc8`): the independent review found two HIGH issues, both fixed: TRANS is now fully substituting (deletes offsets on unmentioned axes, manual §3.12.2.2) and bare absolute frame instructions (ROT/ROTS/CROTS/SCALE/MIRROR) delete the whole programmable frame (§3.12.2.1). Also fixed: grammar regressions for identifiers like `TRANS_X`/`GOTOFFSET` (word boundaries now include `_`), `G1 MIRROR X0` mid-block errors loudly, `DEF REAL PW` is rejected, lowercase `pw=2`/`x=5` are case-normalized, and the library no longer calls `process::exit` on initial_state errors. trans_reset golden extended; 8 new tests (75 passed total at stack tip). **Rebased onto #21** so the stack is linear in the intended merge order.