### PR TITLE
Parse performance: ~15% faster grammar + Sinumerik execution-model doc

### DIFF
--- a/docs/sinumerik-execution-model.md
+++ b/docs/sinumerik-execution-model.md
@@ -1,0 +1,250 @@
+# How a Sinumerik executes NC code — and how this interpreter differs
+
+This interpreter is **not** a Sinumerik emulator. It answers one question:
+*what toolpath would result if this program ran on a Sinumerik?* That goal
+allows — and sometimes requires — a different architecture than the real
+control. This document records how the real control works, where this
+interpreter deliberately deviates, and the measurements behind those
+decisions. Manual references are to the SINUMERIK ONE NC programming manual
+(sections 4.1.5.x, 4.1.7) and the Basic Functions manual (3.5.x).
+
+## The real control: a cursor with a bounded pipeline
+
+A Sinumerik never parses a program file as a whole. It runs a pipeline over
+a *text cursor*, decoding one block (line) at a time:
+
+```
+text cursor ──interpret/decode──► block preparation ──► IPO buffer ──► interpolator
+                                  MD28070, ~10 KB/block   MD28060        (servo clock)
+```
+
+- **MD28070 `$MC_MM_NUM_BLOCKS_IN_PREP`** sets how many blocks can be in
+  preparation at once (roughly 10 KB of dynamic memory is reserved per
+  block). **MD28060 `$MC_MM_IPO_BUFFER_SIZE`** sets the FIFO of fully
+  prepared blocks the interpolator drains (SD42990
+  `$SC_MAX_BLOCKS_IN_IPOBUFFER` can throttle it). Together they form the
+  "lookahead window" of a few hundred to a few thousand blocks that runs
+  ahead of the actual tool position.
+- **Program start is O(1) in file size.** Starting a program just starts
+  filling the pipeline; a 1 GB program starts as fast as a 1 KB one.
+- **A syntax error is not a parse error but a runtime alarm.** The
+  interpreter stage raises it when the malformed block *enters the
+  preparation window* — typically well before the tool reaches it, but
+  never at program load. A malformed line near the end of a long program is
+  discovered near the end of the run.
+- **`GOTO` is literally a search command.** The destination is found by
+  scanning blocks in the programmed direction (alarm 14080 fires when the
+  *search* fails). Structure keywords work the same way: "when a loop end
+  is detected, a search is made for the loop beginning" (manual 4.1.7).
+  Consequences that only make sense for search-based resolution:
+  - duplicate labels are legal; the *nearest occurrence in the search
+    direction* wins — there is no symbol table;
+  - a `GOTO` to a missing label alarms only when it executes; an
+    unexecuted bad jump is never noticed;
+  - a jump invalidates everything already prepared, so jump commands imply
+    a preprocessing stop — `GOTOS` "internally initiates a STOPRE"
+    (manual 4.1.5.1).
+- **The window is a real limitation.** With "Execution from external
+  source" (program streamed through a bounded reload memory), jump
+  destinations that have left the window are simply *gone*: the program
+  aborts with alarm 14000. Siemens' own streaming-input mode is documented
+  as incompatible with jumps; their recommended fix is EES — execution from
+  storage that supports random access.
+
+The control pays these costs to get bounded memory, instant start and hard
+real-time guarantees. An offline interpreter has none of those constraints.
+
+## What this interpreter does instead
+
+| Aspect | Sinumerik | this interpreter |
+| --- | --- | --- |
+| program loading | streamed through a bounded window | whole file in memory |
+| parsing | per block, on demand, at execution time | whole file up front (pest PEG) |
+| syntax errors | runtime alarm when the block enters the prep window | error before any output row (parse is eager) |
+| structure (`IF`/`ENDIF`, loops) | resolved by runtime keyword search | resolved by the grammar at parse time |
+| jump destinations | directional text search at execution time | directional search over the parsed block list at execution time (same observable semantics, incl. duplicate labels and lazily-detected missing targets) |
+| `M2`/`M17`/`M30` | end of program | end of interpretation (blocks after an executed end marker do not run) |
+| `GOTOS` | restart if the PLC requests it via `enableGoToStart` | continue with the next block (the documented no-request behavior); a restart would produce an unbounded trace |
+| PLC, timing, feed, servo | real | not modeled — the output is the geometric/modal trace, not motion timing |
+| memory | O(window) | O(file + parse tree + trace) |
+
+The one deliberate philosophical difference: **validation is a feature.**
+Knowing up front that a file parses — and getting the error immediately
+when it does not — is worth more to an offline tool than emulating the
+control's discover-errors-at-runtime behavior. Note the asymmetry that
+remains: *syntax* errors are eager here, but *semantic* runtime errors
+(undefined variable, missing jump target, iteration limit) still surface
+only if and when the offending block executes, exactly like the control.
+
+## Is eager whole-file parsing fast enough? (benchmark)
+
+Harness: `src/interpreter.rs`, test `parse_speed_1m_lines` — generates a
+deterministic 1M-line large-format-additive-style flood file (~29 MB:
+mostly `X.. Y.. Z..` moves, some with `E`, `A/B/C`, an external axis,
+modal `G1 F..`, block numbers, comments, spline sections) and times the
+pest parse and the full `nc_to_table` pipeline separately.
+
+```
+cargo test --release --lib parse_speed -- --ignored --nocapture
+# BENCH_LINES=... and BENCH_MODE=xyz|g1|g54|elx|comment|bspline isolate shapes
+```
+
+Results on an Apple-silicon laptop (release build, best of 3, ±10% run
+noise):
+
+| stage | 1M lines / 29 MB |
+| --- | --- |
+| pest parse | **3.2 s** (~310 klines/s, ~9 MB/s) |
+| full `nc_to_table` (parse + interpret + table) | **5.6 s** |
+| parse tree size | ~14.3 pairs/line (14.3M pairs) |
+| peak RSS, whole pipeline | ~1.7 GB (≈ 57× input) |
+
+So the "<10 s for 1M lines" goal holds with ~3× headroom, and parse time
+is roughly linear in line count.
+
+### What the profile showed
+
+Sampling profile (samply) of the parse:
+
+- ~30% of time in `pest::ParserState::match_insensitive` — the `^"KEYWORD"`
+  matcher. The volume came from ordered-choice walls: every line attempted
+  the control-statement keywords before falling through to statements, and
+  every bare axis word attempted `identifier`, whose `reserved`
+  negative-lookahead tries ~20 case-insensitive keywords. G-commands like
+  `G54` walk ~115 literals through the gg-group walls (gg08 alone holds
+  ~100 `G5xx` literals sorted longest-first).
+- Per-line cost is remarkably flat (~3.5 µs) regardless of content: the
+  floor is pest's combinator machinery itself (boxed parser state, token
+  queue, implicit-whitespace calls), not any single rule.
+
+### Optimizations applied (measured on the mixed flood)
+
+1. `axis_word` fast path hoisted to the front of `statement`, so flood
+   coordinates never touch `identifier`/`reserved`.
+2. `statement+` tried before `control` in `block` — safe because every
+   control keyword is in `reserved` and can never parse as a statement
+   (`definition` and `frame_op` must stay first: `DEF`/`TRANS`/... are not
+   reserved, deliberately, so identifiers like `TRANS_X` keep working).
+3. `comment` made atomic — pest otherwise runs the implicit-whitespace rule
+   between *every character* of every comment.
+4. `value` made atomic — the interpreter only reads the lexeme, so the
+   inner `float`/`integer` pairs were two dead tokens per coordinate.
+
+Net effect: 3.74 s → 3.2 s parse (~15%), 17.5M → 14.3M pairs. The
+remaining time is pest's structural floor; a substantially faster front
+end (10×+) would mean replacing pest with a hand-rolled line lexer, which
+is not currently worth the grammar-maintainability loss.
+
+A trap worth recording: **PEG ordered choice commits.** In
+`(^"GOTO" | ^"GOTOF" ...) ~ boundary`, an input `GOTOF` matches `^"GOTO"`,
+the boundary check fails on `F`, and the whole expression fails *without
+trying* `^"GOTOF"`. Keyword alternatives sharing a prefix must be sorted
+longest-first (`reserved`, `goto_kw`, and the generated gg-groups all do
+this now). Reordering rules for speed can expose latent shadowing bugs —
+the golden-file suite is the safety net.
+
+## Scaling limits and the road to streaming
+
+Extrapolating: ~10M lines (≈300 MB) parses in ~35 s and needs several GB —
+workable. A true 1 GB program (~35M lines) would need ~2 minutes and tens
+of GB peak for tree + trace: **whole-file eager parsing stops being the
+right answer somewhere around 10⁷ lines.** The control's architecture
+shows the escape hatch, adapted for an offline tool that can afford one
+cheap whole-file pass:
+
+1. *Line index*: one newline scan (we already compute `line_offsets`).
+2. *Skeleton scan*: same pass records labels, block numbers and structure
+   keywords — an O(1) jump table instead of the control's O(distance)
+   search, same observable semantics.
+3. *Lazy per-line parsing*: pest stays, entry rule `block`, parsed when the
+   cursor first reaches a line; hot lines (loop bodies) memoized.
+4. *Execution cursor* instead of recursion, yielding `(line_no, row)` —
+   which is also exactly the streaming/generator API a robot-cell
+   simulator or visualizer wants (`next()` → source line + next trace
+   row), and makes seek-by-checkpoint (snapshot of `pc` + `State`) cheap.
+
+Until programs of that size actually appear, eager parsing keeps the
+stronger up-front guarantees at trivial cost.
+
+## Two-pass triage: measured on real CAM output
+
+Real post-processor output (mill-sim `test-case-1`, eight programs,
+393,724 lines total) is even more skewed than the synthetic flood:
+
+- **99.96–100% of lines** match a conservative "trivial line" shape:
+  `N<d>` + words that are `LETTER<num>`, `ident=<num>`, `G<d>`/`M<d>` or a
+  bare known keyword, plus an optional comment. The entire remainder
+  across all eight files is ~30 lines (`DEF`, `TRANS ...=expr`,
+  `SETAL(...)`, `TRAORI`, ...) — all *single-line* constructs.
+- **Zero control structures.** CAM output is straight-line; IF/WHILE/GOTO
+  appear in hand-written parametric programs, which are small.
+
+A prototype byte-level scanner for exactly that shape (in the
+`parse_speed` bench, `BENCH_FILE=...`), decoding key/value pairs as it
+goes:
+
+| | 319,591-line real program (20.6 MB) |
+| --- | --- |
+| whole-file pest parse | 2.37 s (8.7 MB/s), 13.8M pairs (~43/line) |
+| stage-1 scanner | **52 ms (395 MB/s)**, 3 lines left for pest |
+
+So the two-pass design — triage lines with a fast scanner, give only the
+non-trivial remainder to pest, merge by line order — costs ~45× less than
+parsing everything with the full grammar, extrapolates a 1 GB file to
+~3 s instead of ~2 minutes, and eliminates the parse-tree memory for
+flood lines entirely. pest is demoted to what it is good at: the rare,
+structurally interesting lines.
+
+Prerequisites for a production version (the prototype only proves the
+shape): bare words may only be claimed via the G-keyword vocabulary table
+(otherwise `GOTOF LABEL` would be mistaken for two harmless words), which
+requires moving that table out of the grammar into Rust first; an owned
+per-line block representation so fast-decoded and pest-parsed lines merge
+into one executable list (the same owned IR the streaming VM needs); and
+drift control — a differential-test mode that re-parses every claimed
+line with pest and asserts identical effects, run over the goldens and
+the mill-sim corpus. Simplest correct v1 policy: if the file contains any
+control-structure keyword, fall back to whole-file pest.
+
+## Requirement: good errors when a file does not parse
+
+Up-front validation is only as valuable as its error messages. The
+current state, probed with representative mistakes:
+
+| mistake | today | quality |
+| --- | --- | --- |
+| `G1 X10 Y=` (incomplete expression) | right line, caret, "expected expression or axis_increment" | good — pest at its best |
+| missing `ENDIF` | error at EOF ("expected comment, control, …"), nothing points at the unclosed `IF` | bad — PEG reports the farthest position, not the cause |
+| `G1 X10 Y2O` (letter-O typo) | **no error** — `Y2O` silently becomes a subprogram-call column, the Y move is dropped | worst case |
+| `G999` (unknown G code) | **no error** — silently a subprogram call | bad (real control: alarm 12470) |
+| `GOTOF LAB1`, label typo'd elsewhere | precise runtime error with search direction and alarm reference | good, could add did-you-mean |
+
+Four distinct problem classes, four distinct fixes:
+
+1. **Wrong-position structural errors** (unclosed IF/WHILE/…): a PEG
+   cannot say "the IF on line 2 is never closed" — it fails at EOF. The
+   *line-level structure scan* from the triage design matches opener and
+   closer keywords per line and reports exactly that, before pest runs.
+   The same pass that indexes jump labels fixes the worst error class.
+2. **Silent misparse through the catch-all**: arbitrary bare words are
+   legal (subprogram calls), so the grammar cannot reject them — but the
+   interpreter can diagnose: `G<digits>` not in the vocabulary table →
+   hard error ("unknown G code", matching alarm 12470); a bare word
+   shaped like `LETTER<digits><junk>` → "did you mean an axis word?"
+   warning. Needs the vocabulary table in Rust — the gg-group extraction
+   again.
+3. **Noisy expected-sets and internal rule names** leaking into messages
+   (`gg08_work_offset`, `non_returning_function_call`): pest's
+   `Error::renamed_rules` maps rule names to human phrasing ("a G code",
+   "an axis word", …); cheap, immediate.
+4. **One error per run**: whole-file parsing stops at the first failure.
+   Per-line parsing (the triage architecture) isolates errors — every
+   line validates independently, so a validation pass can report *all*
+   bad lines with exact positions in one round trip.
+
+The notable conclusion: the error-quality requirement *strengthens* the
+two-pass line-oriented design rather than arguing for more grammar. A
+whole-file PEG gives one error, sometimes at the wrong place; per-line
+triage plus a structure scan plus a vocabulary table give multi-error
+reports, matched-pair diagnostics and did-you-mean — while pest stays
+exactly where its errors are good: inside complex single lines.

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -3,8 +3,17 @@ blocks              =  { block ~ (newline ~ block)* }
 newline             = _{ "\n" | "\r\n" }
 WHITESPACE          = _{ " " | "\t" }
 QUOTE               = _{ "\"" }
-comment             =  { ";" ~ (!newline ~ ANY)* }
-block               =  { block_number_set? ~ label_def? ~ (definition | frame_op | control | statement*) ~ comment? }
+// Atomic: without @ pest would attempt the implicit WHITESPACE rule between
+// every single character of the comment body, which measurably dominates
+// comment-heavy files.
+comment             = @{ ";" ~ (!newline ~ ANY)* }
+// Alternatives are ordered for parse speed on coordinate-flood programs:
+// statements are tried before control, which is safe because every control
+// keyword (IF, GOTO.., CASE, LOOP, FOR, WHILE, REPEAT) is in `reserved` and
+// therefore can never parse as a statement. definition and frame_op must
+// stay in front: DEF/TRANS/... are not reserved words, so a statement would
+// otherwise swallow them as function calls or assignments.
+block               =  { block_number_set? ~ label_def? ~ (definition | frame_op | statement+ | control)? ~ comment? }
 block_number_set    = _{ "N" ~ block_number }
 control             =  {
     gotos_statement
@@ -52,7 +61,8 @@ condition              =  { base_condition | ("(" ~ base_condition ~ ")") }
 base_condition         = _{ (expression ~ relational_operator ~ expression) | expression }
 relational_operator    =  { "<=" | ">=" | "==" | "<>" | "<" | ">" }
 statement              =  {
-    g_command_numbered
+    axis_word
+  | g_command_numbered
   | m_command
   | tool_selection
   | assignment_multi
@@ -60,6 +70,14 @@ statement              =  {
   | g_command
   | non_returning_function_call
 }
+// Fast path for the by-far most common statement in real programs: a bare
+// axis word like `X123.456`. Semantically identical to the first alternative
+// of `assignment`, but hoisted above `assignment_multi` so that flood lines
+// of coordinates skip the identifier rule (whose reserved-word lookahead
+// tries ~19 case-insensitive keywords) entirely - that lookahead dominated
+// the parse profile. The `!"["` guard keeps arrays whose name happens to
+// look like an axis word (e.g. `X1[2]=...`) flowing to assignment_multi.
+axis_word              =  { variable_single_char ~ value ~ !"[" }
 
 // local variable definitions
 definition = { ^"DEF" ~ data_type ~ (assignment_multi | assignment | variable_array | variable) ~ ("," ~ (assignment_multi | assignment | variable_array | variable))* }
@@ -71,11 +89,13 @@ reserved   = _{
     ^"IF"
   | ^"ELSE"
   | ^"ENDIF"
-  | ^"GOTO"
+  // Longest first: PEG choice commits, so GOTO would shadow GOTOB/GOTOF/
+  // GOTOC/GOTOS (the boundary check then fails without retrying).
   | ^"GOTOB"
   | ^"GOTOF"
   | ^"GOTOC"
   | ^"GOTOS"
+  | ^"GOTO"
   | ^"CASE"
   | ^"OF"
   | ^"DEFAULT"
@@ -124,7 +144,9 @@ assignment_multi =  { variable_array ~ "=" ~ (value_array | value_repeating) }
 value_array      =  { "SET" ~ "(" ~ (expression | value_none) ~ ("," ~ (expression | value_none))* ~ ")" }
 value_repeating  =  { "REP" ~ "(" ~ expression ~ ("," ~ expression)? ~ ")" }
 value_none       =  { "" }
-value            =  { float | integer }
+// Atomic: the interpreter only reads the full lexeme (as_str), so the inner
+// float/integer pairs would be two dead tokens per coordinate on the queue.
+value            = @{ float | integer }
 op               = _{ op_add | op_sub | op_mul | op_div | op_int_div | op_mod }
 op_add           =  { "+" }
 op_sub           =  { "-" }

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -1353,7 +1353,9 @@ fn interpret_statement(
                     flow = BlockFlow::EndProgram;
                 }
             }
-            Rule::assignment => {
+            // axis_word is the hoisted fast-path form of assignment's first
+            // alternative; both carry (variable_single_char, value) inners.
+            Rule::assignment | Rule::axis_word => {
                 let (key, local_value) = interpret_assignment(statement, state)?;
                 if state.is_axis(&key) {
                     // State keeps local coordinates; the output row gets the machine

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -87,3 +87,265 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
         BlockFlow::Jump(request) => Err(request.into_not_found_error()),
     }
 }
+
+#[cfg(test)]
+mod parse_speed {
+    // NCParser and pest::Parser arrive via the glob from the parent module's
+    // imports; explicit re-imports here would be redundant (though legal -
+    // a glob import may be shadowed, only two explicit imports collide).
+    use super::*;
+    use std::fmt::Write as _;
+    use std::time::Instant;
+
+    /// Deterministic pseudo-random generator (LCG) so the benchmark input is
+    /// reproducible without pulling in a rand dependency.
+    struct Lcg(u64);
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            self.0 >> 33
+        }
+        fn coord(&mut self) -> f64 {
+            (self.next() % 2_000_000) as f64 / 1000.0 - 1000.0
+        }
+    }
+
+    /// Generate a large-format-additive-style flood file: mostly linear moves
+    /// in XYZ, sometimes ABC, an E axis, an external axis, occasional modal
+    /// G codes, block numbers, comments and spline sections.
+    fn generate_flood(lines: usize) -> String {
+        let mut rng = Lcg(42);
+        let mut out = String::with_capacity(lines * 40);
+        out.push_str("; synthetic parse benchmark\nG54 G90 G17\nG1 F2400\nX0 Y0 Z0 E0\n");
+        let mut in_spline = false;
+        for i in 0..lines {
+            let x = rng.coord();
+            let y = rng.coord();
+            let z = rng.coord();
+            match rng.next() % 1000 {
+                0..=699 => {
+                    let _ = writeln!(out, "X{:.3} Y{:.3} Z{:.3}", x, y, z);
+                }
+                700..=849 => {
+                    let _ = writeln!(out, "X{:.3} Y{:.3} Z{:.3} E{:.3}", x, y, z, rng.coord().abs());
+                }
+                850..=909 => {
+                    let _ = writeln!(out, "G1 X{:.3} Y{:.3} F{}", x, y, 1200 + rng.next() % 4800);
+                }
+                910..=949 => {
+                    let _ = writeln!(
+                        out,
+                        "X{:.3} Y{:.3} Z{:.3} A{:.3} B{:.3} C{:.3}",
+                        x,
+                        y,
+                        z,
+                        rng.coord() / 10.0,
+                        rng.coord() / 10.0,
+                        rng.coord() / 10.0
+                    );
+                }
+                950..=969 => {
+                    let _ = writeln!(out, "X{:.3} Y{:.3} ELX={:.3}", x, y, rng.coord());
+                }
+                970..=984 => {
+                    let _ = writeln!(out, "N{} X{:.3} Y{:.3}", i, x, y);
+                }
+                985..=994 => {
+                    let _ = writeln!(out, "; layer {} progress marker", i);
+                }
+                _ => {
+                    if in_spline {
+                        out.push_str("G1\n");
+                    } else {
+                        out.push_str("BSPLINE\n");
+                    }
+                    in_spline = !in_spline;
+                    let _ = writeln!(out, "X{:.3} Y{:.3} Z{:.3} PW=1.5", x, y, z);
+                }
+            }
+        }
+        out.push_str("M30\n");
+        out
+    }
+
+    /// Stage-1 prototype: byte-level scanner for trivially decodable lines.
+    /// Returns the sum of decoded numeric values (so the optimizer cannot
+    /// remove the extraction work), or None when the line needs the full
+    /// grammar. Deliberately conservative: any unexpected byte rejects.
+    fn scan_trivial_line(line: &str) -> Option<f64> {
+        let b = line.as_bytes();
+        let mut i = 0usize;
+        let mut sum = 0.0f64;
+        let n = b.len();
+        let skip_ws = |i: &mut usize| while *i < n && (b[*i] == b' ' || b[*i] == b'\t') { *i += 1 };
+        let parse_num = |i: &mut usize| -> Option<f64> {
+            let start = *i;
+            if *i < n && b[*i] == b'-' { *i += 1; }
+            let digits_start = *i;
+            while *i < n && b[*i].is_ascii_digit() { *i += 1; }
+            if *i == digits_start { return None; }
+            if *i < n && b[*i] == b'.' {
+                *i += 1;
+                while *i < n && b[*i].is_ascii_digit() { *i += 1; }
+            }
+            // reject 1e5 / 100X style tails; those need the real grammar
+            if *i < n && (b[*i].is_ascii_alphabetic() || b[*i] == b'_') { return None; }
+            line[start..*i].parse::<f64>().ok()
+        };
+        skip_ws(&mut i);
+        // optional block number
+        if i + 1 < n && (b[i] == b'N' || b[i] == b'n') && b[i + 1].is_ascii_digit() {
+            i += 1;
+            while i < n && b[i].is_ascii_digit() { i += 1; }
+            skip_ws(&mut i);
+        }
+        while i < n {
+            if b[i] == b';' { break; } // trailing comment: fine
+            if !b[i].is_ascii_alphabetic() && b[i] != b'_' { return None; }
+            let word_start = i;
+            i += 1;
+            // single letter followed directly by a number: axis/address word
+            if i < n && (b[i].is_ascii_digit() || b[i] == b'-' || b[i] == b'.') {
+                sum += parse_num(&mut i)?;
+            } else {
+                // multi-char word: bare keyword or ident=number
+                while i < n && (b[i].is_ascii_alphanumeric() || b[i] == b'_') { i += 1; }
+                if i < n && b[i] == b'=' {
+                    i += 1;
+                    sum += parse_num(&mut i)?;
+                } else {
+                    // bare word (G-keyword, M-code was covered above, CP,
+                    // TRAORI...): claimable only with a vocabulary table;
+                    // prototype counts it as claimed with value 0. A real
+                    // implementation looks it up and falls back on miss.
+                    let _word = &line[word_start..i];
+                }
+            }
+            skip_ws(&mut i);
+        }
+        Some(sum)
+    }
+
+    /// Not a correctness test: prints parse/interpret throughput for a 1M
+    /// line flood file. Run with:
+    /// cargo test --release --lib parse_speed -- --ignored --nocapture
+    #[test]
+    #[ignore = "performance benchmark, run explicitly in release mode"]
+    fn parse_speed_1m_lines() {
+        let lines = std::env::var("BENCH_LINES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1_000_000usize);
+        // BENCH_FILE parses a real program instead of the synthetic flood;
+        // BENCH_MODE isolates a single line shape to attribute parse cost.
+        if let Ok(path) = std::env::var("BENCH_FILE") {
+            let input = std::fs::read_to_string(&path).expect("BENCH_FILE must be readable");
+            let lines = input.lines().count();
+            println!("input: {} ({} lines, {:.1} MB)", path, lines, input.len() as f64 / 1_048_576.0);
+            let start = Instant::now();
+            let pairs = NCParser::parse(Rule::file, &input).expect("BENCH_FILE must parse");
+            let parse_time = start.elapsed();
+            println!(
+                "pest parse:      {:>8.2?}  ({:.0} klines/s, {:.1} MB/s)",
+                parse_time,
+                lines as f64 / parse_time.as_secs_f64() / 1000.0,
+                input.len() as f64 / 1_048_576.0 / parse_time.as_secs_f64()
+            );
+            println!("tree pairs: {}", pairs.flatten().count());
+
+            // Prototype of a stage-1 "trivial line" scanner: claims lines of
+            // the shape [N<d>] (WORD)* [;comment] where WORD is LETTER<num>,
+            // ident=<num>, G<d>/M<d>, or a bare word - i.e. no expressions,
+            // no control flow, no DEF/TRANS. Decodes key/value pairs as it
+            // goes so the timing includes real extraction work.
+            let start = Instant::now();
+            let mut claimed = 0usize;
+            let mut fallback = 0usize;
+            let mut checksum = 0.0f64;
+            for line in input.lines() {
+                match scan_trivial_line(line) {
+                    Some(sum) => {
+                        claimed += 1;
+                        checksum += sum;
+                    }
+                    None => fallback += 1,
+                }
+            }
+            let scan_time = start.elapsed();
+            println!(
+                "stage-1 scan:    {:>8.2?}  ({:.0} klines/s, {:.1} MB/s) - {} claimed, {} fall back to pest ({:.3}%), checksum {:.1}",
+                scan_time,
+                lines as f64 / scan_time.as_secs_f64() / 1000.0,
+                input.len() as f64 / 1_048_576.0 / scan_time.as_secs_f64(),
+                claimed,
+                fallback,
+                100.0 * fallback as f64 / lines as f64,
+                checksum
+            );
+            return;
+        }
+        let input = match std::env::var("BENCH_MODE").as_deref() {
+            Ok("xyz") => {
+                let mut rng = Lcg(42);
+                let mut out = String::with_capacity(lines * 40);
+                for _ in 0..lines {
+                    let _ = writeln!(out, "X{:.3} Y{:.3} Z{:.3}", rng.coord(), rng.coord(), rng.coord());
+                }
+                out
+            }
+            Ok("g1") => {
+                let mut rng = Lcg(42);
+                let mut out = String::with_capacity(lines * 40);
+                for _ in 0..lines {
+                    let _ = writeln!(out, "G1 X{:.3} Y{:.3} F2400", rng.coord(), rng.coord());
+                }
+                out
+            }
+            Ok("g54") => "G54\n".repeat(lines),
+            Ok("elx") => {
+                let mut rng = Lcg(42);
+                let mut out = String::with_capacity(lines * 40);
+                for _ in 0..lines {
+                    let _ = writeln!(out, "X{:.3} Y{:.3} ELX={:.3}", rng.coord(), rng.coord(), rng.coord());
+                }
+                out
+            }
+            Ok("comment") => "; layer progress marker\n".repeat(lines),
+            Ok("bspline") => "BSPLINE\n".repeat(lines),
+            _ => generate_flood(lines),
+        };
+        println!(
+            "input: {} lines, {:.1} MB",
+            lines,
+            input.len() as f64 / 1_048_576.0
+        );
+
+        let start = Instant::now();
+        let pairs = NCParser::parse(Rule::file, &input).expect("benchmark input must parse");
+        let parse_time = start.elapsed();
+        println!(
+            "pest parse:      {:>8.2?}  ({:.0} klines/s, {:.1} MB/s)",
+            parse_time,
+            lines as f64 / parse_time.as_secs_f64() / 1000.0,
+            input.len() as f64 / 1_048_576.0 / parse_time.as_secs_f64()
+        );
+
+        let start = Instant::now();
+        let token_count = pairs.flatten().count();
+        println!(
+            "tree iteration:  {:>8.2?}  ({} pairs)",
+            start.elapsed(),
+            token_count
+        );
+
+        let start = Instant::now();
+        let (table, _state) =
+            nc_to_table(&input, None, None, None, 10_000, false, None, false).expect("interpret");
+        println!(
+            "full nc_to_table:{:>8.2?}  ({} rows, {} columns)",
+            start.elapsed(),
+            table.columns.first().map_or(0, |(_, c)| c.len()),
+            table.columns.len()
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #29 (uses its grammar rules; retarget to main after #29 merges).

## What's here

**`docs/sinumerik-execution-model.md`** — the learnings write-up: how a real Sinumerik executes NC code (bounded block-preparation pipeline per MD28070/MD28060, syntax errors as runtime alarms when a block enters the lookahead window, GOTO as a directional text search, GOTOS ⇒ STOPRE) versus this interpreter's deliberate whole-file-parse-up-front design, why eager validation is a feature for an offline toolpath oracle, the benchmark numbers, and the scaling limit (~10⁷ lines) with the lazy line-indexed escape hatch sketched for the future.

**Benchmark harness** — `parse_speed_1m_lines` (`#[ignore]`d test): deterministic 1M-line AM-style flood file; times pest parse and full `nc_to_table` separately. `BENCH_LINES` / `BENCH_MODE=xyz|g1|g54|elx|comment|bspline` isolate shapes.

**Grammar optimizations** (profile-driven; ~30% of parse time was in `match_insensitive` from ordered-choice keyword walls):
- bare axis-word fast path hoisted in `statement` (flood lines skip `identifier`'s reserved lookahead)
- `statement+` before `control` in `block` (safe: all control keywords are reserved)
- `comment` atomic (implicit WHITESPACE ran between every comment character)
- `value` atomic (dead `float`/`integer` pairs, two per coordinate)
- fix latent PEG prefix-shadowing in `reserved` (`GOTO` committed before `GOTOF` could be tried) — exposed by the reorder, caught by the test suite

## Numbers (1M lines / 29 MB, best of 3)

| | before | after |
|---|---|---|
| pest parse | 3.74 s | **3.2 s** |
| full `nc_to_table` | 6.3 s | **5.6 s** |
| parse-tree pairs | 17.5 M | 14.3 M |

All 122 Python tests pass; every example golden regenerates byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3