### PR TITLE
Diagnostics: unknown-G errors, typo warnings, human parse errors, did-you-mean

### DIFF
--- a/python/tests/test_diagnostics.py
+++ b/python/tests/test_diagnostics.py
@@ -1,0 +1,63 @@
+"""Diagnostics: silent-misparse guards, human parse errors, did-you-mean."""
+
+import pytest
+from nc_gcode_interpreter import nc_to_dataframe
+
+
+def test_unknown_g_code_errors():
+    """A bare G<digits> word that matches no G group is an unknown G code
+    (alarm 12470 on a real control), not a silent subprogram call."""
+    with pytest.raises(ValueError, match="not a G code"):
+        nc_to_dataframe("G1 X10\nG999\nX5")
+
+
+def test_lowercase_unknown_g_code_errors():
+    with pytest.raises(ValueError, match="not a G code"):
+        nc_to_dataframe("g999")
+
+
+def test_axis_word_typo_warns_but_keeps_call_semantics(capfd):
+    """Y2O (letter O typo for Y20) stays a subprogram call, but the silent
+    loss of the intended axis move is flagged on stderr."""
+    df, _state = nc_to_dataframe("G1 X10 Y2O\nX5")
+    assert df["non_returning_function_call"][0] == "Y2O"
+    assert "Y2O" in capfd.readouterr().err
+
+
+def test_call_with_arguments_does_not_warn(capfd):
+    df, _state = nc_to_dataframe("SETAL(67037)\nX5")
+    assert "Warning" not in capfd.readouterr().err
+
+
+def test_parse_errors_use_human_phrasing():
+    """Grammar-internal rule names (gg08_work_offset, label_name, ...) must
+    not leak into parse error messages."""
+    with pytest.raises(ValueError) as excinfo:
+        nc_to_dataframe("X1\nIF R1>0\nX2\nX3")
+    message = str(excinfo.value)
+    assert "label_name" not in message
+    assert "frame_kw" not in message
+    assert "gg0" not in message
+    assert "expected" in message
+
+
+def test_jump_error_suggests_similar_label():
+    with pytest.raises(ValueError, match="Did you mean 'ENDE'"):
+        nc_to_dataframe("GOTOF ENDF\nX1\nENDE: M30")
+
+
+def test_jump_error_without_similar_label_has_no_suggestion():
+    with pytest.raises(ValueError) as excinfo:
+        nc_to_dataframe("GOTOF COMPLETELY_DIFFERENT\nX1\nENDE: M30")
+    assert "Did you mean" not in str(excinfo.value)
+
+
+def test_jump_to_existing_label_in_wrong_direction_hints_direction():
+    """A label that exists but lies behind a GOTOF must not produce a
+    'did you mean' with the very same name; the problem is the direction."""
+    with pytest.raises(ValueError) as excinfo:
+        nc_to_dataframe("BEHIND: X1\nGOTOF BEHIND\nX2\nM30")
+    message = str(excinfo.value)
+    assert "Did you mean" not in message
+    assert "'BEHIND' is defined" in message
+    assert "GOTOB" in message

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -133,7 +133,7 @@ Jump destination not found on line {line_no}
 Line: {preview}
 
 Details: No block with the jump label or block number '{target}' was found
-searching {search_direction} (alarm 14080 on a real control).
+searching {search_direction} (alarm 14080 on a real control).{hint}
 Note: jump destinations inside IF/LOOP/FOR/WHILE/REPEAT bodies cannot be
 reached from outside those bodies.
 "#)]
@@ -142,6 +142,22 @@ reached from outside those bodies.
         preview: String,
         target: String,
         search_direction: String,
+        /// Either empty or a "\nDid you mean '...'?" suggestion line.
+        hint: String,
+    },
+    #[error(r#"
+Unknown G code on line {line_no}
+----------------------------------------
+Line: {preview}
+
+Details: '{code}' is not a G code known to this interpreter (a real control
+raises alarm 12470 "undefined G function"). If this is meant to be a
+subprogram call, note that program names cannot look like a G code.
+"#)]
+    UnknownGCommand {
+        line_no: usize,
+        preview: String,
+        code: String,
     },
     #[error(r#"
 Invalid function call on line {line_no}

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -33,14 +33,75 @@ pub struct JumpRequest {
 }
 
 impl JumpRequest {
-    pub fn into_not_found_error(self) -> ParsingError {
+    pub fn into_not_found_error(self, state: &State) -> ParsingError {
+        // When the destination exists as written, "did you mean" would
+        // absurdly suggest the very name the user typed; the actual problem
+        // is the search direction or the scope it is defined in.
+        let hint = if state.seen_jump_targets.contains(&self.key) {
+            let reason = match self.direction {
+                JumpDirection::Forward => {
+                    "GOTOF only searches toward the end of the program; use GOTOB or GOTO for a destination that lies before this block"
+                }
+                JumpDirection::Backward => {
+                    "GOTOB only searches toward the beginning of the program; use GOTOF or GOTO for a destination that lies after this block"
+                }
+                JumpDirection::BothForwardFirst => "a jump cannot enter an IF or loop body from outside",
+            };
+            format!(
+                "\n'{}' is defined, but not where this jump searches: {}.",
+                self.display, reason
+            )
+        } else {
+            suggest_jump_target(&self.key, &state.seen_jump_targets)
+                .map(|s| format!("\nDid you mean '{}'?", s))
+                .unwrap_or_default()
+        };
         ParsingError::JumpTargetNotFound {
             line_no: self.line_no,
             preview: self.preview,
             target: self.display,
             search_direction: self.direction.search_description().to_string(),
+            hint,
         }
     }
+}
+
+/// Suggest the closest jump target of the same kind (label or block number)
+/// within a small edit distance, for "did you mean" hints.
+fn suggest_jump_target(key: &str, seen: &std::collections::HashSet<String>) -> Option<String> {
+    let mut best: Option<(usize, &str)> = None;
+    for candidate in seen {
+        // Keys are prefixed "LABEL:"/"N:", so kinds can never cross-match
+        // within distance 2 unless the names themselves are close.
+        // Distance 0 (the target exists) is handled by the caller with a
+        // direction/scope hint; suggesting the same name would be absurd.
+        let distance = edit_distance(key, candidate);
+        if (1..=2).contains(&distance) && best.map_or(true, |(d, _)| distance < d) {
+            best = Some((distance, candidate));
+        }
+    }
+    best.map(|(_, c)| {
+        c.strip_prefix("LABEL:")
+            .map(str::to_string)
+            .or_else(|| c.strip_prefix("N:").map(|n| format!("N{}", n)))
+            .unwrap_or_else(|| c.to_string())
+    })
+}
+
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut current = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let substitution = prev[j] + usize::from(ca != cb);
+            current[j + 1] = substitution.min(prev[j + 1] + 1).min(current[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut current);
+    }
+    prev[b.len()]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1295,6 +1356,25 @@ fn is_end_of_program_m_code(code: &str) -> bool {
     matches!(digits.trim_start_matches('0'), "2" | "17" | "30")
 }
 
+/// True for words shaped like a G code: G followed by digits only.
+fn is_g_number_shaped(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some('G') | Some('g'))
+        && name.len() > 1
+        && chars.all(|c| c.is_ascii_digit())
+}
+
+/// True for words that look like an axis word with a typo or a missing
+/// space: a letter directly followed by a digit, with more letters later
+/// (Y2O, X10Y20). Legitimate subprogram names rarely have this shape.
+fn looks_like_axis_word_typo(name: &str) -> bool {
+    let chars: Vec<char> = name.chars().collect();
+    chars.len() >= 3
+        && chars[0].is_ascii_alphabetic()
+        && chars[1].is_ascii_digit()
+        && chars[2..].iter().any(|c| c.is_ascii_alphabetic())
+}
+
 fn interpret_statement(
     element: Pair<Rule>,
     output: &mut Output,
@@ -1316,7 +1396,29 @@ fn interpret_statement(
         let last = output.last_mut().expect("Output vector should not be empty");
         match statement.as_rule() {
             Rule::non_returning_function_call => {
+                let (line_no, preview) = get_error_context(&statement, state);
                 let (key, value) = interpret_non_returning_function_call(statement);
+                let name = value.split('(').next().unwrap_or("").trim();
+                // A bare G<digits> word can only land here when no G-group
+                // matched it: an unknown G code. Program names may not look
+                // like a G code, so this is never a legitimate call.
+                if is_g_number_shaped(name) {
+                    return Err(ParsingError::UnknownGCommand {
+                        line_no,
+                        preview,
+                        code: name.to_uppercase(),
+                    });
+                }
+                // A parenless word like Y2O or X10Y20 is far more likely a
+                // mistyped axis word than a subprogram call; the toolpath
+                // would silently lose a move. Warn, but keep the call
+                // semantics: only the user can tell.
+                if !value.contains('(') && looks_like_axis_word_typo(name) {
+                    eprintln!(
+                        "Warning: '{}' (line {}) is interpreted as a subprogram call; did you mean one or more axis words (e.g. Y20)?",
+                        name, line_no
+                    );
+                }
                 last.insert(key, Value::Str(value));
             }
             Rule::g_command => {
@@ -1543,6 +1645,7 @@ pub fn interpret_blocks(
     }
     let block_pairs: Vec<Pair<Rule>> = blocks.into_inner().collect();
     let targets = scan_jump_targets(&block_pairs);
+    state.seen_jump_targets.extend(targets.keys().cloned());
     state.jump_scopes.push(targets.keys().cloned().collect());
     let result = run_blocks(&block_pairs, &targets, output, state);
     state.jump_scopes.pop();

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -66,7 +66,7 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
                 pest::error::LineColLocation::Span(start, _) => *start,
             };
             let preview = state.get_line(line).unwrap_or("(could not retrieve line)").to_string();
-            ParsingError::with_context(line, preview, "initial file parsing".to_string(), format!("{}", e))
+            ParsingError::with_context(line, preview, "initial file parsing".to_string(), describe_parse_error(&e))
         })?
         .next()
         .ok_or_else(|| ParsingError::ParseError {
@@ -84,7 +84,83 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
         BlockFlow::Continue | BlockFlow::EndProgram => Ok(results),
         // A jump that no scope could resolve: the destination does not exist
         // in the programmed search direction (alarm 14080 on a real control).
-        BlockFlow::Jump(request) => Err(request.into_not_found_error()),
+        BlockFlow::Jump(request) => Err(request.into_not_found_error(state)),
+    }
+}
+
+/// Turn a pest parse error into a human message: the expected-rule set is
+/// mapped to user-facing phrasing and deduplicated (all sixty G-group rules
+/// collapse into one "a G code" entry) instead of leaking grammar-internal
+/// rule names like `gg08_work_offset`.
+fn describe_parse_error(error: &pest::error::Error<Rule>) -> String {
+    use pest::error::ErrorVariant;
+    match &error.variant {
+        ErrorVariant::ParsingError { positives, .. } if !positives.is_empty() => {
+            let mut expected: Vec<&'static str> = Vec::new();
+            for rule in positives {
+                let description = describe_rule(*rule);
+                if !expected.contains(&description) {
+                    expected.push(description);
+                }
+            }
+            format!("expected {}", expected.join(", or "))
+        }
+        _ => format!("{}", error),
+    }
+}
+
+fn describe_rule(rule: Rule) -> &'static str {
+    match rule {
+        Rule::file | Rule::blocks | Rule::block => "an NC block",
+        Rule::newline => "a new line",
+        Rule::EOI => "the end of the program",
+        Rule::comment => "a comment (;...)",
+        Rule::statement => "a statement",
+        Rule::axis_word => "an axis word (e.g. X12.5)",
+        Rule::variable_single_char => "an axis letter",
+        Rule::assignment => "an assignment",
+        Rule::assignment_multi => "an array assignment (SET/REP)",
+        Rule::axis_increment => "an incremental value IC(...)",
+        Rule::expression | Rule::primary => "an expression",
+        Rule::value | Rule::float | Rule::integer => "a number",
+        Rule::identifier | Rule::variable => "a name",
+        Rule::variable_array => "an array element",
+        Rule::indices => "array indices",
+        Rule::nc_variable => "a $-variable",
+        Rule::arith_fun | Rule::arith_fun_name => "an arithmetic function",
+        Rule::function_arguments => "function arguments",
+        Rule::non_returning_function_call => "a subprogram call",
+        Rule::quoted_string | Rule::string => "a quoted string",
+        Rule::tool_selection => "a tool selection (T=\"...\")",
+        Rule::definition => "a variable definition (DEF)",
+        Rule::data_type => "a data type (REAL/INT/BOOL)",
+        Rule::control => "a control statement",
+        Rule::condition => "a condition",
+        Rule::relational_operator => "a comparison operator",
+        Rule::if_statement | Rule::if_goto_statement => "IF",
+        Rule::while_statement => "WHILE",
+        Rule::for_statement => "FOR",
+        Rule::repeat_until_statement => "REPEAT",
+        Rule::loop_statement => "LOOP",
+        Rule::case_statement | Rule::case_kw => "CASE",
+        Rule::case_arm => "a CASE arm (<constant> GOTO...)",
+        Rule::case_default | Rule::default_kw => "DEFAULT",
+        Rule::of_kw => "OF",
+        Rule::goto_statement | Rule::goto_kw => "a jump (GOTO/GOTOF/GOTOB/GOTOC)",
+        Rule::gotos_statement => "GOTOS",
+        Rule::goto_target => "a jump destination (label or block number)",
+        Rule::label_def | Rule::label_name => "a jump label",
+        Rule::block_number => "a block number",
+        Rule::frame_op | Rule::frame_kw => "a frame instruction (TRANS/ROT/...)",
+        Rule::m_command => "an M code",
+        Rule::g_command | Rule::g_command_numbered => "a G code",
+        Rule::op_add | Rule::op_sub | Rule::op_mul | Rule::op_div | Rule::op_int_div | Rule::op_mod | Rule::neg => {
+            "an operator"
+        }
+        Rule::value_array | Rule::value_repeating | Rule::value_none => "SET/REP values",
+        Rule::WHITESPACE => "whitespace",
+        // Everything not listed is one of the generated G-group rules.
+        _ => "a G code",
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,6 +20,9 @@ pub struct State {
     /// `blocks` scope, innermost last. Used by GOTOC to decide whether its
     /// destination exists anywhere on the scope chain before jumping.
     pub jump_scopes: Vec<HashSet<String>>,
+    /// Every jump target seen anywhere during the run (never popped), used
+    /// for "did you mean" suggestions when a jump destination is not found.
+    pub seen_jump_targets: HashSet<String>,
     /// Store line offsets for efficient error reporting
     line_offsets: Vec<usize>,
     /// Store the input text for error messages
@@ -62,6 +65,7 @@ impl State {
             axis_index_map,
             allow_undefined_variables,
             jump_scopes: Vec::new(),
+            seen_jump_targets: HashSet::new(),
             line_offsets: Vec::new(),
             input: String::new(),
         }


### PR DESCRIPTION
Stacked on #30. First of the planned error-quality series (see docs/sinumerik-execution-model.md, "Requirement: good errors").

- **Unknown G codes are hard errors.** `G999` used to silently become a `non_returning_function_call` column value; now: "'G999' is not a G code known to this interpreter (a real control raises alarm 12470)". Program names may not look like a G code, so no legitimate case is lost.
- **Axis-word-typo warning.** `G1 X10 Y2O` (letter O for zero... or digit 0 typo'd to O) silently dropped the Y move into a call column — the worst possible failure for a toolpath oracle. It still parses as a call (a subprogram really could be named that), but now warns on stderr with a "did you mean an axis word" hint. Parenthesized calls (`SETAL(...)`) never warn.
- **Human parse errors.** pest's expected-sets are mapped and deduplicated: `expected a comment (;...), or a control statement, or a jump label, or a statement, ...` instead of `expected comment, control, label_name, statement, definition, or frame_kw`; the sixty generated gg rules collapse to one "a G code" entry.
- **Did-you-mean for jumps.** `GOTOF ENDF` with a label `ENDE:` now appends "Did you mean 'ENDE'?" (edit distance ≤ 2 over all labels/block numbers seen).

7 new tests; 129 pass; goldens byte-identical.

Next in the series per the plan: G-vocabulary table in Rust (#B), then the line-level structure scan that fixes the "missing ENDIF reported at EOF" case (#C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3