### PR TITLE
Stage-1 line triage: byte-decode trivial lines, pest only for the rest

### DIFF
--- a/docs/sinumerik-execution-model.md
+++ b/docs/sinumerik-execution-model.md
@@ -202,16 +202,24 @@ parsing everything with the full grammar, extrapolates a 1 GB file to
 flood lines entirely. pest is demoted to what it is good at: the rare,
 structurally interesting lines.
 
-Prerequisites for a production version (the prototype only proves the
-shape): bare words may only be claimed via the G-keyword vocabulary table
-(otherwise `GOTOF LABEL` would be mistaken for two harmless words), which
-requires moving that table out of the grammar into Rust first; an owned
-per-line block representation so fast-decoded and pest-parsed lines merge
-into one executable list (the same owned IR the streaming VM needs); and
-drift control — a differential-test mode that re-parses every claimed
-line with pest and asserts identical effects, run over the goldens and
-the mill-sim corpus. Simplest correct v1 policy: if the file contains any
-control-structure keyword, fall back to whole-file pest.
+This design is now implemented in `src/line_driver.rs`, gated by the
+structure scan: programs without multi-line control structures (all CAM
+output; labels and the whole GOTO family remain supported since jumps are
+line-scoped) are interpreted line by line — trivial lines through a
+conservative byte decoder, the rare rest through per-line pest parses
+padded to their file position so error messages keep whole-file
+coordinates. Bare words are claimed only via the vocabulary table, so
+`GOTOF LABEL` and reserved words always take the grammar. `NC_STAGE1=0`
+disables the fast path; the differential tests
+(`python/tests/test_stage1.py`) run synthetic edge cases and the whole
+mill-sim corpus through both paths and assert identical output.
+
+Measured on the 319k-line Sheffield program, end to end: the Rust CLI
+(decode + execute + table + CSV) went 5.0 s → **2.9 s**, and
+`nc_to_dataframe` from Python 33 s → **9 s**. Parsing has left the
+profile entirely; what remains is row assembly (`HashMap` rows,
+forward-fill, the pyo3 → polars conversion), which is the natural target
+of the streaming-rows work.
 
 ## Requirement: good errors when a file does not parse
 

--- a/python/tests/test_stage1.py
+++ b/python/tests/test_stage1.py
@@ -1,0 +1,108 @@
+"""Differential tests for the stage-1 line triage: every program must
+produce identical output with the fast path enabled (default) and disabled
+(NC_STAGE1=0, whole-file parse). The fast path only exists because it is
+provably equivalent on the lines it claims."""
+
+import os
+import pathlib
+
+import pytest
+from nc_gcode_interpreter import nc_to_dataframe
+from polars.testing import assert_frame_equal
+
+
+def run_both(program, **kwargs):
+    previous = os.environ.get("NC_STAGE1")
+    try:
+        os.environ["NC_STAGE1"] = "0"
+        full_df, full_state = nc_to_dataframe(program, **kwargs)
+        os.environ["NC_STAGE1"] = "1"
+        fast_df, fast_state = nc_to_dataframe(program, **kwargs)
+    finally:
+        if previous is None:
+            os.environ.pop("NC_STAGE1", None)
+        else:
+            os.environ["NC_STAGE1"] = previous
+    assert_frame_equal(full_df, fast_df, check_column_order=False)
+    assert full_state["symbol_table"] == fast_state["symbol_table"]
+    assert full_state["axes"] == fast_state["axes"]
+    assert full_state["translation"] == fast_state["translation"]
+    return fast_df
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        # plain flood shapes
+        "X1 Y2 Z3\nX4 Y5 Z6",
+        "N10 X1.5 Y-2. Z0.001\nN20 X2 F2400 S8000 D1",
+        "G1 X1 Y1\nG0 X0\nG54\nG17 G94 G90",
+        "BSPLINE\nX1 Y1 PW=1.5\nX2 Y2 PW=0.5\nG1",
+        "X1 A=0.0 B=-1.5 C=90. ELX=3087.022334",
+        # comments, blanks, N-only lines
+        "; header\nX1 ; move\n\nN100\nX2",
+        # M codes incl. end-of-program mid-file
+        "X1 M3\nX2 M170\nM30\nX999",
+        "X1 M101 M102 M2 M3 M4",
+        # jumps, labels, block numbers (line-scoped control)
+        "GOTOF SKIP\nX999\nSKIP: X2",
+        "N40 R1=30 R2=10 R4=3\nN41 LA1: X=R1\nN42 R1=R1+10 R4=R4-1\nN43 IF R4>0 GOTOB LA1\nN44 M30",
+        "N10 GOTOF 40\nN20 X999\nN40 X4\nN50 GOTO N70\nN60 X999\nN70 X7",
+        "GOTOC NOWHERE\nX2",
+        "CASE(5) OF 7 GOTOF SEVEN DEFAULT GOTOF OTHER\nSEVEN: X7\nGOTOF ENDE\nOTHER: X0\nENDE: M30",
+        "GOTOS\nX1",
+        # lines the decoder must reject to pest, mixed with claimed ones
+        "DEF REAL DEPTH=2.5\nX=DEPTH\nTRANS X10\nX1\nTRANS\nX2",
+        "R1=1+2\nX=R1*3\nY=SIN(30)\nZ=IC(5)",
+        "T=\"drill\"\nX1\nT5",
+        "x100\nX100",  # lowercase bare word is a call, uppercase an axis move
+        "N10 lowercase=5\nX=lowercase",
+        # duplicate block numbers with a directional jump
+        "N10 X1\nGOTOF N10\nN10 X2",
+    ],
+    ids=lambda p: p.splitlines()[0][:30],
+)
+def test_fast_path_matches_full_parse(program):
+    run_both(program)
+
+
+def test_fast_path_matches_with_extra_axes_and_index_map(tmp_path):
+    program = "N10 X1 ELX=100\nFL[E]=10\nN20 X2 ELX=200 E5"
+    run_both(program, extra_axes=["ELX"], axis_index_map={"E": 4})
+
+
+def test_structured_programs_take_the_full_path():
+    """Programs with IF/WHILE bodies bypass the fast path entirely and must
+    still work (this exercises the shape gate)."""
+    df, _state = nc_to_dataframe("R1=1\nIF R1==1\nX5\nENDIF\nX6")
+    assert df["X"].drop_nulls().to_list() == [5.0, 6.0]
+
+
+def test_grammar_heavy_program_declines_the_fast_path():
+    """When most lines need the per-line grammar, the newline padding that
+    keeps pest positions correct would cost O(n^2) memory; the line driver
+    must decline and the whole-file parse take over, transparently."""
+    lines = 5000  # padding would be ~12.5 MB, over the 4 MB budget
+    program = "\n".join("X=SIN(30)" for _ in range(lines))
+    df, _state = nc_to_dataframe(program)
+    assert df.height == lines
+    assert abs(df["X"][0] - 0.5) < 1e-12
+
+
+MILL_SIM = pathlib.Path(
+    # Override with NC_TEST_CORPUS to run the corpus tests elsewhere; they
+    # are skipped when the directory does not exist.
+    os.environ.get("NC_TEST_CORPUS", "/Users/thijsdamsma/projects/mill-sim/test-case-1")
+)
+
+
+@pytest.mark.skipif(not MILL_SIM.exists(), reason="mill-sim corpus not available")
+@pytest.mark.parametrize(
+    "mpf", sorted(MILL_SIM.glob("*.mpf")), ids=lambda p: p.name[:40]
+)
+def test_fast_path_matches_on_real_corpus(mpf):
+    run_both(
+        mpf.read_text(errors="replace"),
+        extra_axes=["ELX"],
+        allow_undefined_variables=True,
+    )

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,4 +1,8 @@
 file                =  { SOI ~ blocks ~ newline? ~ EOI }
+// Entry point for parsing one line in isolation (stage-1 triage). Leading
+// newlines are allowed so a line can be parsed padded to its original file
+// position, keeping error positions in whole-file coordinates.
+line_entry          = _{ SOI ~ newline* ~ block ~ EOI }
 blocks              =  { block ~ (newline ~ block)* }
 newline             = _{ "\n" | "\r\n" }
 WHITESPACE          = _{ " " | "\t" }

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -128,7 +128,7 @@ impl JumpDirection {
 /// key that matches `scan_jump_targets`. Labels are case-insensitive; block
 /// numbers may be written as `200` or `N200` (manual 4.1.5.2) and are
 /// normalized so `N020` and `20` compare equal.
-fn canonical_jump_target(raw: &str) -> String {
+pub(crate) fn canonical_jump_target(raw: &str) -> String {
     let trimmed = raw.trim();
     let digits = trimmed.strip_prefix(['N', 'n']).unwrap_or(trimmed);
     if !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()) {
@@ -138,7 +138,7 @@ fn canonical_jump_target(raw: &str) -> String {
     }
 }
 
-fn canonical_block_number(digits: &str) -> &str {
+pub(crate) fn canonical_block_number(digits: &str) -> &str {
     let stripped = digits.trim_start_matches('0');
     if stripped.is_empty() { "0" } else { stripped }
 }
@@ -146,7 +146,7 @@ fn canonical_block_number(digits: &str) -> &str {
 /// Collect the jump targets (labels and block numbers) defined by each block
 /// of a scope, mapping the canonical key to the (ascending) block indices
 /// where it is defined.
-fn scan_jump_targets(block_pairs: &[Pair<Rule>]) -> HashMap<String, Vec<usize>> {
+pub(crate) fn scan_jump_targets(block_pairs: &[Pair<Rule>]) -> HashMap<String, Vec<usize>> {
     let mut targets: HashMap<String, Vec<usize>> = HashMap::new();
     for (index, block) in block_pairs.iter().enumerate() {
         for item in block.clone().into_inner() {
@@ -177,7 +177,7 @@ fn scan_jump_targets(block_pairs: &[Pair<Rule>]) -> HashMap<String, Vec<usize>> 
 /// backward from the current block (inclusive), GOTOF forward (exclusive),
 /// GOTO/GOTOC forward first and then backward. Returns the destination block
 /// index, or None when the target is not reachable in this scope.
-fn resolve_jump(
+pub(crate) fn resolve_jump(
     targets: &HashMap<String, Vec<usize>>,
     current: usize,
     request: &JumpRequest,
@@ -196,7 +196,7 @@ fn resolve_jump(
 /// rule at block start. Also present in G-group 3, where they can only be
 /// reached when they FOLLOW another statement in the block - which is invalid
 /// (frame instructions must be alone in the block) and rejected loudly.
-const FRAME_KEYWORDS: &[&str] = &[
+pub(crate) const FRAME_KEYWORDS: &[&str] = &[
     "TRANS", "ATRANS", "SCALE", "ASCALE", "ROT", "AROT", "ROTS", "AROTS", "CROTS", "MIRROR", "AMIRROR",
 ];
 fn interpret_primary(primary: Pair<Rule>, state: &mut State) -> Result<f64, ParsingError> {
@@ -1333,7 +1333,7 @@ fn interpret_control(
     }
     Ok(BlockFlow::Continue)
 }
-fn insert_m_key(last: &mut HashMap<String, Value>, value: &str, line_no: usize, preview: String) -> Result<(), ParsingError> {
+pub(crate) fn insert_m_key(last: &mut HashMap<String, Value>, value: &str, line_no: usize, preview: String) -> Result<(), ParsingError> {
     let m_key = "M";
     for _i in 1..=5 {
         if let Some(existing_value) = last.get_mut(m_key) {
@@ -1364,7 +1364,7 @@ fn insert_m_key(last: &mut HashMap<String, Value>, value: &str, line_no: usize, 
 /// M codes that end the program: M2/M02 and M30 end a main program, M17 a
 /// subprogram. Execution of one of these stops interpretation; the rest of
 /// the containing block still executes.
-fn is_end_of_program_m_code(code: &str) -> bool {
+pub(crate) fn is_end_of_program_m_code(code: &str) -> bool {
     let digits = code.trim_start_matches(['M', 'm']);
     matches!(digits.trim_start_matches('0'), "2" | "17" | "30")
 }
@@ -1601,7 +1601,7 @@ fn annotate_error(pair: &Pair<Rule>, context: &str, message: String, state: &Sta
     )
 }
 
-fn interpret_block(
+pub(crate) fn interpret_block(
     element: Pair<Rule>,
     output: &mut Output,
     state: &mut State,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -58,10 +58,24 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
 
     // Validate control-structure nesting first: a PEG reports an unclosed
     // IF/WHILE at the end of the file; the line scan reports the opener.
-    crate::structure_scan::check_structures(input)?;
+    let shape = crate::structure_scan::check_structures(input)?;
 
     // Initialize results with an empty HashMap
     let mut results = vec![HashMap::new()];
+
+    // Stage-1 fast path: structure-free programs (all CAM output) are
+    // interpreted line by line - trivial lines through the byte decoder,
+    // the rest through per-line pest parses. NC_STAGE1=0 disables it.
+    if !shape.has_block_structures && crate::line_driver::stage1_enabled() {
+        let mut padded_lines = Vec::new();
+        // None: the line driver declined (padding budget); fall through to
+        // the whole-file parse below.
+        match crate::line_driver::interpret_lines(input, &mut padded_lines, &mut results, state)? {
+            Some(BlockFlow::Continue) | Some(BlockFlow::EndProgram) => return Ok(results),
+            Some(BlockFlow::Jump(request)) => return Err(request.into_not_found_error(state)),
+            None => {}
+        }
+    }
 
     let file = NCParser::parse(Rule::file, input)
         .map_err(|e| {
@@ -96,7 +110,7 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
 /// mapped to user-facing phrasing and deduplicated (all sixty G-group rules
 /// collapse into one "a G code" entry) instead of leaking grammar-internal
 /// rule names like `gg08_work_offset`.
-fn describe_parse_error(error: &pest::error::Error<Rule>) -> String {
+pub(crate) fn describe_parse_error(error: &pest::error::Error<Rule>) -> String {
     use pest::error::ErrorVariant;
     match &error.variant {
         ErrorVariant::ParsingError { positives, .. } if !positives.is_empty() => {
@@ -248,64 +262,6 @@ mod parse_speed {
         out
     }
 
-    /// Stage-1 prototype: byte-level scanner for trivially decodable lines.
-    /// Returns the sum of decoded numeric values (so the optimizer cannot
-    /// remove the extraction work), or None when the line needs the full
-    /// grammar. Deliberately conservative: any unexpected byte rejects.
-    fn scan_trivial_line(line: &str) -> Option<f64> {
-        let b = line.as_bytes();
-        let mut i = 0usize;
-        let mut sum = 0.0f64;
-        let n = b.len();
-        let skip_ws = |i: &mut usize| while *i < n && (b[*i] == b' ' || b[*i] == b'\t') { *i += 1 };
-        let parse_num = |i: &mut usize| -> Option<f64> {
-            let start = *i;
-            if *i < n && b[*i] == b'-' { *i += 1; }
-            let digits_start = *i;
-            while *i < n && b[*i].is_ascii_digit() { *i += 1; }
-            if *i == digits_start { return None; }
-            if *i < n && b[*i] == b'.' {
-                *i += 1;
-                while *i < n && b[*i].is_ascii_digit() { *i += 1; }
-            }
-            // reject 1e5 / 100X style tails; those need the real grammar
-            if *i < n && (b[*i].is_ascii_alphabetic() || b[*i] == b'_') { return None; }
-            line[start..*i].parse::<f64>().ok()
-        };
-        skip_ws(&mut i);
-        // optional block number
-        if i + 1 < n && (b[i] == b'N' || b[i] == b'n') && b[i + 1].is_ascii_digit() {
-            i += 1;
-            while i < n && b[i].is_ascii_digit() { i += 1; }
-            skip_ws(&mut i);
-        }
-        while i < n {
-            if b[i] == b';' { break; } // trailing comment: fine
-            if !b[i].is_ascii_alphabetic() && b[i] != b'_' { return None; }
-            let word_start = i;
-            i += 1;
-            // single letter followed directly by a number: axis/address word
-            if i < n && (b[i].is_ascii_digit() || b[i] == b'-' || b[i] == b'.') {
-                sum += parse_num(&mut i)?;
-            } else {
-                // multi-char word: bare keyword or ident=number
-                while i < n && (b[i].is_ascii_alphanumeric() || b[i] == b'_') { i += 1; }
-                if i < n && b[i] == b'=' {
-                    i += 1;
-                    sum += parse_num(&mut i)?;
-                } else {
-                    // bare word (G-keyword, M-code was covered above, CP,
-                    // TRAORI...): claimable only with a vocabulary table;
-                    // prototype counts it as claimed with value 0. A real
-                    // implementation looks it up and falls back on miss.
-                    let _word = &line[word_start..i];
-                }
-            }
-            skip_ws(&mut i);
-        }
-        Some(sum)
-    }
-
     /// Not a correctness test: prints parse/interpret throughput for a 1M
     /// line flood file. Run with:
     /// cargo test --release --lib parse_speed -- --ignored --nocapture
@@ -333,35 +289,6 @@ mod parse_speed {
             );
             println!("tree pairs: {}", pairs.flatten().count());
 
-            // Prototype of a stage-1 "trivial line" scanner: claims lines of
-            // the shape [N<d>] (WORD)* [;comment] where WORD is LETTER<num>,
-            // ident=<num>, G<d>/M<d>, or a bare word - i.e. no expressions,
-            // no control flow, no DEF/TRANS. Decodes key/value pairs as it
-            // goes so the timing includes real extraction work.
-            let start = Instant::now();
-            let mut claimed = 0usize;
-            let mut fallback = 0usize;
-            let mut checksum = 0.0f64;
-            for line in input.lines() {
-                match scan_trivial_line(line) {
-                    Some(sum) => {
-                        claimed += 1;
-                        checksum += sum;
-                    }
-                    None => fallback += 1,
-                }
-            }
-            let scan_time = start.elapsed();
-            println!(
-                "stage-1 scan:    {:>8.2?}  ({:.0} klines/s, {:.1} MB/s) - {} claimed, {} fall back to pest ({:.3}%), checksum {:.1}",
-                scan_time,
-                lines as f64 / scan_time.as_secs_f64() / 1000.0,
-                input.len() as f64 / 1_048_576.0 / scan_time.as_secs_f64(),
-                claimed,
-                fallback,
-                100.0 * fallback as f64 / lines as f64,
-                checksum
-            );
             return;
         }
         let input = match std::env::var("BENCH_MODE").as_deref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod interpret_rules;
 pub mod interpreter;
 mod modal_groups;
 pub mod output;
+mod line_driver;
 mod state;
 mod structure_scan;
 

--- a/src/line_driver.rs
+++ b/src/line_driver.rs
@@ -1,0 +1,459 @@
+//! Stage-1 line triage: the per-line fast path for structure-free programs.
+//!
+//! Real CAM output is >99.9% lines of the shape
+//! `N38 X-45.414 Y-8.835 Z49. A=0.0 ELX=3083.63 ; comment` — no
+//! expressions, no definitions, no control flow. Parsing such a line with
+//! the full grammar costs microseconds and ~40 parse-tree pairs; a byte
+//! scanner decodes it in nanoseconds. This module claims exactly those
+//! trivial lines and hands every other line to pest individually, so the
+//! full grammar still owns everything structurally interesting.
+//!
+//! Scope: only programs without multi-line control structures
+//! (IF/WHILE/FOR/LOOP/REPEAT blocks) take this path — the structure scan
+//! decides. Labels, block numbers and the whole GOTO family remain
+//! supported: jump statements are line-scoped, parse via pest, and resolve
+//! against the line index built here.
+//!
+//! Correctness policy: the decoder is conservative (any unexpected byte
+//! rejects the line to pest) and must replicate the interpreter's effects
+//! exactly for the lines it claims; the differential test mode in
+//! python/tests/test_stage1.py re-runs programs with the fast path
+//! disabled and asserts identical output.
+
+use crate::errors::ParsingError;
+use crate::interpret_rules::{
+    canonical_block_number, insert_m_key, interpret_block,
+    is_end_of_program_m_code, resolve_jump, scan_jump_targets, BlockFlow,
+};
+use crate::modal_groups::classify_g_command;
+use crate::state::State;
+use crate::types::{NCParser, Pair, Rule, Value};
+use pest::Parser;
+use std::collections::HashMap;
+
+type Output = Vec<HashMap<String, Value>>;
+
+/// One word of a decoded trivial line, in source order.
+enum Word {
+    /// `X12.5` or `AXIS=12.5`: routed to axis / block address / variable
+    /// exactly like `interpret_assignment` would.
+    Assign(String, f64),
+    /// A vocabulary-known keyword or `G<digits>` command: (group, as written).
+    GCommand(&'static str, String),
+    /// An M code, as written.
+    MCode(String),
+}
+
+struct DecodedLine {
+    line_no: usize,
+    n: Option<String>,
+    comment: Option<String>,
+    words: Vec<Word>,
+    /// The line defines a jump label (recorded in the target index only).
+    has_content: bool,
+}
+
+enum LineExec<'i> {
+    Decoded(DecodedLine),
+    /// A pest-parsed block. The line was parsed with `line_entry` padded
+    /// with leading newlines so that all positions (and therefore error
+    /// messages) are correct in whole-file coordinates.
+    Parsed(Pair<'i, Rule>),
+    Blank,
+}
+
+/// Interpret a structure-free program line by line. Mirrors
+/// `interpret_blocks` for a flat block list: jumps resolve against the
+/// line index; an unresolved jump propagates to the caller.
+///
+/// Returns `Ok(None)` - before touching `output` or `state` - when the
+/// program does not suit the fast path after all (see the padding budget
+/// below); the caller then runs the whole-file parse instead.
+pub fn interpret_lines(
+    input: &str,
+    padded_lines: &mut Vec<String>,
+    output: &mut Output,
+    state: &mut State,
+) -> Result<Option<BlockFlow>, ParsingError> {
+    // Pass 1: decode every line (owned results, no borrows).
+    let lines: Vec<&str> = input.lines().collect();
+    let mut decode_results: Vec<DecodeResult> = Vec::with_capacity(lines.len());
+    let mut padding_bytes: usize = 0;
+    for (index, line) in lines.iter().enumerate() {
+        let result = decode_line(line, index + 1, state);
+        if matches!(result, DecodeResult::NeedsGrammar) {
+            padding_bytes += index;
+        }
+        decode_results.push(result);
+    }
+
+    // The newline padding gives pest whole-file positions, but costs
+    // O(line_no) bytes per grammar-parsed line. A program where many late
+    // lines need the grammar would degenerate to O(n²) memory; decline and
+    // let the whole-file parse handle it (it parses everything once anyway).
+    // Real CAM output is >99.9% trivial lines, so it never comes close.
+    if padding_bytes > input.len().max(1 << 22) {
+        return Ok(None);
+    }
+
+    // Prepare the newline-padded copies for the lines that need the grammar.
+    for (index, result) in decode_results.iter().enumerate() {
+        padded_lines.push(match result {
+            DecodeResult::NeedsGrammar => {
+                // Pad with newlines so pest reports whole-file positions.
+                let mut padded = "\n".repeat(index);
+                padded.push_str(lines[index]);
+                padded
+            }
+            _ => String::new(),
+        });
+    }
+
+    // Pass 2: parse the non-trivial lines, build the jump-target index and
+    // the executable list. padded_lines is only read from here on, so the
+    // parsed pairs may borrow from it.
+    let mut targets: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut execs: Vec<LineExec> = Vec::with_capacity(decode_results.len());
+    for (index, result) in decode_results.into_iter().enumerate() {
+        match result {
+            DecodeResult::Trivial(decoded, label) => {
+                if let Some(n) = &decoded.n {
+                    targets
+                        .entry(format!("N:{}", canonical_block_number(n)))
+                        .or_default()
+                        .push(index);
+                }
+                if let Some(label) = label {
+                    targets.entry(format!("LABEL:{}", label)).or_default().push(index);
+                }
+                execs.push(LineExec::Decoded(decoded));
+            }
+            DecodeResult::Blank => execs.push(LineExec::Blank),
+            DecodeResult::NeedsGrammar => {
+                let block = parse_single_line(&padded_lines[index], index + 1, state)?;
+                for key in scan_jump_targets(std::slice::from_ref(&block)).into_keys() {
+                    targets.entry(key).or_default().push(index);
+                }
+                execs.push(LineExec::Parsed(block));
+            }
+        }
+    }
+
+    state.seen_jump_targets.extend(targets.keys().cloned());
+    state.jump_scopes.push(targets.keys().cloned().collect());
+    let result = run_lines(&execs, &targets, output, state);
+    state.jump_scopes.pop();
+    result.map(Some)
+}
+
+fn run_lines(
+    execs: &[LineExec],
+    targets: &HashMap<String, Vec<usize>>,
+    output: &mut Output,
+    state: &mut State,
+) -> Result<BlockFlow, ParsingError> {
+    let mut index = 0;
+    let mut jumps_taken = 0;
+    while index < execs.len() {
+        let flow = match &execs[index] {
+            LineExec::Blank => BlockFlow::Continue,
+            LineExec::Decoded(line) => execute_decoded(line, output, state)?,
+            LineExec::Parsed(block) => interpret_block(block.clone(), output, state)?,
+        };
+        match flow {
+            BlockFlow::Continue => index += 1,
+            BlockFlow::EndProgram => return Ok(BlockFlow::EndProgram),
+            BlockFlow::Jump(request) => match resolve_jump(targets, index, &request) {
+                Some(destination) => {
+                    // Only backward jumps can form cycles; bound them like
+                    // the loop statements (same >= threshold). Forward jumps
+                    // strictly advance and are fine in any number.
+                    if destination <= index {
+                        jumps_taken += 1;
+                        if jumps_taken >= state.iteration_limit {
+                            return Err(ParsingError::LoopLimit {
+                                limit: state.iteration_limit.to_string(),
+                            });
+                        }
+                    }
+                    index = destination;
+                }
+                None => return Ok(BlockFlow::Jump(request)),
+            },
+        }
+    }
+    Ok(BlockFlow::Continue)
+}
+
+/// Execute a decoded trivial line: the exact effects of `interpret_block`
+/// on the same line, without the parse tree.
+fn execute_decoded(line: &DecodedLine, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
+    if !line.has_content {
+        return Ok(BlockFlow::Continue);
+    }
+    output.push(HashMap::new());
+    let mut flow = BlockFlow::Continue;
+    // Split borrows: row insertion vs axis-state updates.
+    for word in &line.words {
+        match word {
+            Word::Assign(key, value) => {
+                if state.is_axis(key) {
+                    let machine_value = state.update_axis(key, *value)?;
+                    let last = output.last_mut().expect("row was just pushed");
+                    last.insert(key.clone(), Value::Float(machine_value));
+                } else if state.is_block_address(key) {
+                    let last = output.last_mut().expect("row was just pushed");
+                    last.insert(key.clone(), Value::Float(*value));
+                } else {
+                    state.symbol_table.insert(key.clone(), *value);
+                }
+            }
+            Word::GCommand(group, as_written) => {
+                let last = output.last_mut().expect("row was just pushed");
+                last.insert(group.to_string(), Value::Str(as_written.clone()));
+            }
+            Word::MCode(code) => {
+                let last = output.last_mut().expect("row was just pushed");
+                let preview = state.get_line(line.line_no).unwrap_or("").to_string();
+                insert_m_key(last, code, line.line_no, preview)?;
+                if is_end_of_program_m_code(code) {
+                    flow = BlockFlow::EndProgram;
+                }
+            }
+        }
+    }
+    let last = output.last_mut().expect("row was just pushed");
+    if let Some(n) = &line.n {
+        last.insert("N".to_string(), Value::Str(n.clone()));
+    }
+    if let Some(comment) = &line.comment {
+        last.insert("comment".to_string(), Value::Str(comment.clone()));
+    }
+    Ok(flow)
+}
+
+fn parse_single_line<'i>(
+    padded: &'i str,
+    line_no: usize,
+    state: &State,
+) -> Result<Pair<'i, Rule>, ParsingError> {
+    let parsed = NCParser::parse(Rule::line_entry, padded).map_err(|e| {
+        let preview = state.get_line(line_no).unwrap_or("(could not retrieve line)").to_string();
+        ParsingError::with_context(
+            line_no,
+            preview,
+            "line parsing".to_string(),
+            crate::interpreter::describe_parse_error(&e),
+        )
+    })?;
+    parsed
+        .flatten()
+        .find(|p| p.as_rule() == Rule::block)
+        .ok_or_else(|| ParsingError::ParseError {
+            message: format!("Line {} produced no block", line_no),
+        })
+}
+
+enum DecodeResult {
+    Trivial(DecodedLine, Option<String>),
+    Blank,
+    NeedsGrammar,
+}
+
+/// Byte-level scanner for trivially decodable lines. Conservative: any
+/// construct beyond `N<d>`, `LABEL:`, `LETTER<num>`, `ident=<num>`,
+/// `M<d>`, a vocabulary-known bare keyword and a trailing comment rejects
+/// the line to the full grammar.
+fn decode_line(line: &str, line_no: usize, state: &State) -> DecodeResult {
+    let bytes = line.as_bytes();
+    let n_len = bytes.len();
+    let mut i = 0;
+    let mut words: Vec<Word> = Vec::new();
+    let mut n: Option<String> = None;
+    let mut label: Option<String> = None;
+    let mut comment: Option<String> = None;
+
+    let skip_ws = |i: &mut usize| {
+        while *i < n_len && (bytes[*i] == b' ' || bytes[*i] == b'\t') {
+            *i += 1;
+        }
+    };
+
+    fn parse_number(line: &str, i: &mut usize) -> Option<f64> {
+        let bytes = line.as_bytes();
+        let start = *i;
+        if *i < bytes.len() && bytes[*i] == b'-' {
+            *i += 1;
+        }
+        let digits_start = *i;
+        while *i < bytes.len() && bytes[*i].is_ascii_digit() {
+            *i += 1;
+        }
+        if *i == digits_start {
+            return None;
+        }
+        if *i < bytes.len() && bytes[*i] == b'.' {
+            *i += 1;
+            while *i < bytes.len() && bytes[*i].is_ascii_digit() {
+                *i += 1;
+            }
+        }
+        // Exponents, a second dot, or letter tails need the real grammar.
+        if *i < bytes.len() && (bytes[*i].is_ascii_alphabetic() || bytes[*i] == b'_' || bytes[*i] == b'.') {
+            return None;
+        }
+        line[start..*i].parse::<f64>().ok()
+    }
+
+    skip_ws(&mut i);
+
+    // optional block number ("N" is case-sensitive in the grammar)
+    if i + 1 < n_len && bytes[i] == b'N' && bytes[i + 1].is_ascii_digit() {
+        let start = i + 1;
+        i += 1;
+        while i < n_len && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        n = Some(line[start..i].to_string());
+        skip_ws(&mut i);
+    }
+
+    // optional jump label NAME: (2..32 chars, first two letters/underscore)
+    {
+        let word_len = bytes[i..]
+            .iter()
+            .take_while(|b| b.is_ascii_alphanumeric() || **b == b'_')
+            .count();
+        if word_len >= 2
+            && bytes.get(i + word_len) == Some(&b':')
+            && bytes[i..i + 2].iter().all(|b| b.is_ascii_alphabetic() || *b == b'_')
+            && word_len <= 32
+        {
+            label = Some(line[i..i + word_len].to_uppercase());
+            i += word_len + 1;
+            skip_ws(&mut i);
+        }
+    }
+
+    while i < n_len {
+        if bytes[i] == b';' {
+            comment = Some(line[i..].to_string());
+            break;
+        }
+        if !bytes[i].is_ascii_alphabetic() {
+            return DecodeResult::NeedsGrammar;
+        }
+        let word_start = i;
+        i += 1;
+        let bare_number_follows = i < n_len && (bytes[i].is_ascii_digit() || bytes[i] == b'-' || bytes[i] == b'.');
+        // The grammar's bare-word forms: M/G addresses are case-insensitive,
+        // but variable_single_char (axis letters) is uppercase-only - a
+        // lowercase x100 parses as a subprogram call in the full grammar.
+        if bare_number_follows
+            && (bytes[word_start].is_ascii_uppercase() || matches!(bytes[word_start], b'm' | b'g'))
+        {
+            let letter = bytes[word_start].to_ascii_uppercase();
+            if letter == b'M' || letter == b'G' {
+                // M/G addresses take integer codes and are not axis words.
+                let digits_start = i;
+                while i < n_len && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i == digits_start
+                    || (i < n_len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b'.'))
+                {
+                    return DecodeResult::NeedsGrammar;
+                }
+                let code = &line[word_start..i];
+                if letter == b'M' {
+                    words.push(Word::MCode(code.to_string()));
+                } else {
+                    match classify_g_command(&code.to_uppercase()) {
+                        Some((group, _modal)) => words.push(Word::GCommand(group, code.to_string())),
+                        // Unknown G code: let the full path produce its error.
+                        None => return DecodeResult::NeedsGrammar,
+                    }
+                }
+            } else {
+                // Axis-address letters: exactly the grammar's
+                // variable_single_char set. Anything else needs the grammar.
+                if !matches!(letter, b'X' | b'Y' | b'Z' | b'A' | b'B' | b'C' | b'U' | b'V' | b'W' | b'I' | b'J' | b'K' | b'T' | b'S' | b'F' | b'D' | b'H' | b'E')
+                {
+                    return DecodeResult::NeedsGrammar;
+                }
+                let Some(value) = parse_number(line, &mut i) else {
+                    return DecodeResult::NeedsGrammar;
+                };
+                // The grammar's axis_word rejects a following '[' (arrays).
+                if i < n_len && bytes[i] == b'[' {
+                    return DecodeResult::NeedsGrammar;
+                }
+                let key = (bytes[word_start] as char).to_ascii_uppercase().to_string();
+                words.push(Word::Assign(key, value));
+            }
+        } else {
+            // Multi-character word: keyword command or ident=<number>.
+            while i < n_len && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+            let word = &line[word_start..i];
+            if i < n_len && bytes[i] == b'=' {
+                i += 1;
+                let Some(value) = parse_number(line, &mut i) else {
+                    return DecodeResult::NeedsGrammar;
+                };
+                // Case normalization for axes and block addresses mirrors
+                // normalize_reserved_case; other identifiers keep their case.
+                let key = if state.is_axis(word) || state.is_block_address(word) {
+                    word.to_uppercase()
+                } else {
+                    word.to_string()
+                };
+                words.push(Word::Assign(key, value));
+            } else if i < n_len && !(bytes[i] == b' ' || bytes[i] == b'\t' || bytes[i] == b';') {
+                // '(', '[', quotes, operators...: full grammar.
+                return DecodeResult::NeedsGrammar;
+            } else {
+                match classify_g_command(&word.to_uppercase()) {
+                    // Frame keywords must go through frame_op / the frame
+                    // guard; TRUE/FALSE etc. are not commands. Only claim
+                    // plain keyword commands.
+                    Some((group, _modal))
+                        if !crate::interpret_rules::FRAME_KEYWORDS
+                            .iter()
+                            .any(|kw| kw.eq_ignore_ascii_case(word)) =>
+                    {
+                        words.push(Word::GCommand(group, word.to_string()));
+                    }
+                    // Unknown bare words are subprogram calls, reserved
+                    // words are control flow - both take the full grammar.
+                    _ => return DecodeResult::NeedsGrammar,
+                }
+            }
+        }
+        skip_ws(&mut i);
+    }
+
+    // A line whose only content is a jump label produces no output row
+    // (matching the whole-file path, where the empty row is pruned), but it
+    // still exists as a jump target.
+    let row_content = n.is_some() || comment.is_some() || !words.is_empty();
+    if !row_content && label.is_none() {
+        return DecodeResult::Blank;
+    }
+    let decoded = DecodedLine {
+        line_no,
+        n,
+        comment,
+        words,
+        has_content: row_content,
+    };
+    DecodeResult::Trivial(decoded, label)
+}
+
+/// Escape hatch for differential testing and debugging: NC_STAGE1=0
+/// disables the fast path so everything runs through the whole-file parse.
+pub fn stage1_enabled() -> bool {
+    !std::env::var("NC_STAGE1")
+        .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod errors;
 mod interpret_rules;
 mod interpreter;
 mod modal_groups;
+mod line_driver;
 mod state;
 mod structure_scan;
 mod output;

--- a/src/structure_scan.rs
+++ b/src/structure_scan.rs
@@ -49,8 +49,12 @@ impl Structure {
 /// Validate that every IF/WHILE/FOR/LOOP/REPEAT has its matching closer and
 /// vice versa. Returns the first structural error with the line that caused
 /// it (the opener for a missing closer, the closer for a missing opener).
-pub fn check_structures(input: &str) -> Result<(), ParsingError> {
+/// On success, reports whether the program contains any multi-line control
+/// structure at all: structure-free programs (all CAM output) qualify for
+/// the per-line fast path.
+pub fn check_structures(input: &str) -> Result<ProgramShape, ParsingError> {
     let mut stack: Vec<(Structure, usize, String)> = Vec::new();
+    let mut has_block_structures = false;
 
     for (index, raw_line) in input.lines().enumerate() {
         let line_no = index + 1;
@@ -70,13 +74,26 @@ pub fn check_structures(input: &str) -> Result<(), ParsingError> {
             // jump form (IF <condition> GOTO... <target>).
             "IF" => {
                 if !contains_goto_word(line) {
+                    has_block_structures = true;
                     stack.push((Structure::If, line_no, raw_line.to_string()));
                 }
             }
-            "WHILE" => stack.push((Structure::While, line_no, raw_line.to_string())),
-            "FOR" => stack.push((Structure::For, line_no, raw_line.to_string())),
-            "LOOP" => stack.push((Structure::Loop, line_no, raw_line.to_string())),
-            "REPEAT" => stack.push((Structure::Repeat, line_no, raw_line.to_string())),
+            "WHILE" => {
+                has_block_structures = true;
+                stack.push((Structure::While, line_no, raw_line.to_string()));
+            }
+            "FOR" => {
+                has_block_structures = true;
+                stack.push((Structure::For, line_no, raw_line.to_string()));
+            }
+            "LOOP" => {
+                has_block_structures = true;
+                stack.push((Structure::Loop, line_no, raw_line.to_string()));
+            }
+            "REPEAT" => {
+                has_block_structures = true;
+                stack.push((Structure::Repeat, line_no, raw_line.to_string()));
+            }
             "ELSE" => match stack.last() {
                 Some((Structure::If, _, _)) => {}
                 Some((open, open_line, _)) => {
@@ -131,7 +148,15 @@ pub fn check_structures(input: &str) -> Result<(), ParsingError> {
             ),
         });
     }
-    Ok(())
+    Ok(ProgramShape { has_block_structures })
+}
+
+/// Result of a successful structure scan.
+pub struct ProgramShape {
+    /// True when the program contains IF/WHILE/FOR/LOOP/REPEAT blocks
+    /// (multi-line structures); false for straight-line programs, which
+    /// may still contain labels, jumps and single-line conditional jumps.
+    pub has_block_structures: bool,
 }
 
 fn strip_comment(line: &str) -> &str {
@@ -205,9 +230,9 @@ fn contains_goto_word(line: &str) -> bool {
         if matches!(bytes.get(end), Some(b'F') | Some(b'B') | Some(b'C') | Some(b'S')) {
             end += 1;
         }
-        let followed_ok = bytes
+        let followed_ok = !bytes
             .get(end)
-            .map_or(true, |b| !(b.is_ascii_alphanumeric() || *b == b'_'));
+            .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
         if preceded_ok && followed_ok {
             return true;
         }


### PR DESCRIPTION
Stacked on #33 (top of the series #29→#30→#31→#32→#33). Implements the two-pass idea from the architecture discussion: filter out trivially parsable lines first, parse only the remainder with the full grammar, merge by line order.

## Design

- **Gate**: the structure scan's `ProgramShape` — only programs without multi-line control structures take the fast path (all 8 real corpus files qualify; the real-world corpus has zero structures in 393k lines). Labels, block numbers, and the entire GOTO/CASE family stay supported: jumps are line-scoped and resolve against the driver's line index with the same directional search and iteration limit.
- **Decoder** (`src/line_driver.rs`): conservative byte scanner for `[N<d>] [LABEL:] (LETTER<num> | ident=<num> | G/M codes | vocabulary keywords)* [;comment]`. Any unexpected byte → pest. Bare words are claimed only via the PR #32 vocabulary table; lowercase bare axis letters (grammar: subprogram calls), frame keywords, and reserved words all fall through.
- **Per-line pest** for the remainder, parsed padded with newlines to the original file position — error messages keep whole-file coordinates.
- **Equivalence is enforced**: `NC_STAGE1=0` disables the path; `test_stage1.py` runs 20 synthetic edge cases (jumps, GOTOC, CASE, M2 mid-block, `x100` vs `X100`, duplicate N numbers, extra axes + index maps, …) plus the entire mill-sim corpus through both paths and asserts identical DataFrames and state.

## Numbers (real-world 21 MB (319k-line) program)

| | whole-file pest | stage-1 triage |
|---|---|---|
| Rust CLI end-to-end (incl. CSV) | 5.0 s | **2.9 s** |
| Python `nc_to_dataframe` | 33 s | **9 s** |

Parsing has left the profile entirely. The remaining cost is row assembly (`HashMap` rows, forward-fill) and the pyo3→polars conversion — the natural target of the streaming-rows work (PR E in the plan).

174 tests pass; goldens byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3
