### PR TITLE
Streaming API: nc_to_rows yields (line_no, row) while interpreting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ python/**/*.pyc
 
 # local scratch
 tmp/
+
+# local exploration scripts
+python/example/plot_trace.py
+python/example/smooth_e.py

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The **NC-GCode-Interpreter** offers a streamlined and efficient solution for int
 
 ### Additional Functionality
 
+- **Streaming interpretation**: `nc_to_rows(program)` yields `(line_no, row)` tuples lazily while the interpreter runs on a background thread — constant memory, early exit by dropping the iterator (breaking out of a `for` loop over an anonymous iterator does this; a stored iterator keeps the run alive until it is deleted or garbage-collected), and source-line numbers for mapping trace rows back to the program. With `include_variables=True` it yields `(line_no, row, variables)` instead, exposing every variable assignment (`R1=R1+1`, `DEF`, FOR counters) as it happens — including blocks that only assign variables, which are invisible in the batch DataFrame.
+
 - **Custom Axes**: Allows users to define additional axes beyond the standard `X`, `Y`, `Z`.
 - **Initial State Configuration**: Enables the use of an initial state MPF file to set default values for multiple runs.
 - **CLI Options**: Numerous command-line options to customize the processing, such as axis overriding, loop limits, and more.
@@ -126,6 +128,36 @@ shape: (14, 7)
 ```
 
 The Python bindings also return the state of the program after execution, which can be used for inspection.
+
+#### Streaming
+
+For long programs (or when you want results before the whole file is interpreted), `nc_to_rows` yields rows lazily while the interpreter runs on a background thread. Each row carries the 1-based source line it came from — loops and jumps repeat line numbers, which is exactly what a visualizer needs to map trace rows back to the program:
+
+```python
+from nc_gcode_interpreter import nc_to_rows
+
+program = "R1=0\nWHILE R1<3\nG1 X=R1*10 F1000\nR1=R1+1\nENDWHILE\nM30"
+
+for line_no, row in nc_to_rows(program):
+    print(line_no, row["X"])
+# 3 0.0
+# 3 10.0
+# 3 20.0
+# 6 20.0
+
+# With include_variables=True, every variable assignment streams as a
+# per-row delta - including variable-only blocks, which are invisible in
+# the batch DataFrame. Accumulating the deltas with dict.update
+# reconstructs the full variable state at any point of the stream.
+for line_no, row, variables in nc_to_rows(program, include_variables=True):
+    print(line_no, row.get("X"), variables)
+# 1 None {'R1': 0.0}
+# 3 0.0 {}
+# 4 None {'R1': 1.0}
+# ...
+```
+
+Rows are typed and forward-filled like the batch DataFrame (disable with `forward_fill=False`); errors raise from `next()` at the offending row; after exhaustion the iterator's `state` attribute holds the final interpreter state. See `python/example/streaming.py` for a runnable version.
 
 Additionally, conversion from a Polars DataFrame back to an MPF (NC) program is also supported:
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,10 @@
 - [x] functions not hardcoded
 - [x] allow supplying custom values for builtin variables
 - [x] array syntax
-- [] are variables only internal state, or should they be part of output?
+- [x] are variables only internal state, or should they be part of output? -> internal state in the batch DataFrame; the streaming API exposes them per row via nc_to_rows(include_variables=True)
 - [] is every element in a variable array a separate element/column in the output?
 - [x] case (in)sensitivity
-- [x] write output while parsing -> no, will not do this
+- [x] write output while parsing -> yes after all: nc_to_rows streams rows from a background thread while interpreting
 - [] 4.1.3.1 Arithmetic functions
 - [] Var  PHU 42 LLI 0 ULI 
 - [x] PRESETON(E,0)

--- a/docs/sinumerik-execution-model.md
+++ b/docs/sinumerik-execution-model.md
@@ -218,8 +218,45 @@ Measured on the 319k-line Sheffield program, end to end: the Rust CLI
 (decode + execute + table + CSV) went 5.0 s → **2.9 s**, and
 `nc_to_dataframe` from Python 33 s → **9 s**. Parsing has left the
 profile entirely; what remains is row assembly (`HashMap` rows,
-forward-fill, the pyo3 → polars conversion), which is the natural target
-of the streaming-rows work.
+forward-fill, the pyo3 → polars conversion).
+
+## Streaming rows (nc_to_rows)
+
+The interpreter's output is a sink (`OutputRows`): collected into the
+batch table, or pushed row by row into a bounded channel drained by a
+Python iterator while interpretation runs on a worker thread.
+`nc_to_rows(program, ...)` yields `(line_no, row_dict)` — the 1-based
+source line each block came from (loops and jumps repeat and reorder
+line numbers, which is exactly what a visualizer needs for
+trace-to-source highlighting), and values typed and forward-filled like
+the batch DataFrame. Dropping the iterator hangs up the channel and
+aborts interpretation — breaking out of a `for` loop over an anonymous
+iterator drops it, but a stored iterator keeps the worker alive (parked
+on the bounded channel) until it is deleted or garbage-collected.
+Errors raise from `next()` at the offending row; the final state is
+available on the iterator once exhausted.
+
+On the 319k-line Sheffield program: the first row arrives after ~1.6 s
+(the price of eager whole-file validation — the decode/parse passes run
+before execution starts), a full drain takes ~8.6 s versus ~10 s for the
+batch DataFrame, and memory stays constant. The differential tests
+(`python/tests/test_streaming.py`) assert the streamed rows reconstruct
+the batch DataFrame exactly.
+
+With `include_variables=True` the iterator yields `(line_no, row_dict,
+variables_dict)` instead: every variable assignment a block performs
+(`R1=R1+1`, `DEF REAL Q=5`, FOR counters — the counter increment
+surfaces on the ENDFOR line, where the control performs it) arrives as
+a per-row delta, and blocks that only assign variables — pruned from
+the batch DataFrame — are streamed too, with an empty row dict. A live
+query of the interpreter's symbol table would be wrong by construction
+(the worker runs ahead of the consumer behind the channel buffer);
+deltas riding on the rows are race-free, and accumulating them with
+`dict.update` reconstructs the full variable state at any row.
+
+Not yet built: checkpoints (`position` + `State` snapshot) for
+seek/scrub in a visualizer — straightforward on top of the line driver
+when the need arrives.
 
 ## Requirement: good errors when a file does not parse
 

--- a/python/example/streaming.py
+++ b/python/example/streaming.py
@@ -1,0 +1,31 @@
+# %%
+from nc_gcode_interpreter import nc_to_rows
+
+program = """
+DEF REAL depth=2.5
+R1=0
+WHILE R1<3
+G1 X=R1*10 Z=-depth F1000
+R1=R1+1
+ENDWHILE
+M30
+"""
+
+# Rows stream while the interpreter runs on a background thread: constant
+# memory, and each row carries the source line it came from (loops repeat
+# line numbers - exactly what a visualizer needs for trace-to-source
+# highlighting).
+for line_no, row in nc_to_rows(program):
+    print(f"line {line_no}: X={row.get('X')} Z={row.get('Z')}")
+
+# %%
+# include_variables=True also streams every variable assignment as a
+# per-row delta - including blocks that only assign variables, which are
+# invisible in the batch DataFrame. Accumulating the deltas reconstructs
+# the full variable state at any point of the stream.
+variables = {}
+for line_no, row, changes in nc_to_rows(program, include_variables=True):
+    variables.update(changes)
+    print(f"line {line_no}: {row or '(no output)'} variables={variables}")
+
+# %%

--- a/python/nc_gcode_interpreter/__init__.py
+++ b/python/nc_gcode_interpreter/__init__.py
@@ -1,6 +1,7 @@
 from typing import Protocol
 import polars as pl
 from ._internal import nc_to_columns as _nc_to_columns
+from ._internal import nc_to_rows as _nc_to_rows
 from ._internal import __doc__  # noqa: F401
 import json
 from pathlib import Path
@@ -13,7 +14,7 @@ class TextFileLike(Protocol):
     def read(self) -> str: ...
 
 
-__all__ = ["nc_to_dataframe", "sanitize_dataframe", "dataframe_to_nc"]
+__all__ = ["nc_to_dataframe", "nc_to_rows", "sanitize_dataframe", "dataframe_to_nc"]
 
 
 def nc_to_dataframe(
@@ -321,3 +322,72 @@ def dataframe_to_nc(df: pl.DataFrame, file_path: str | Path):
         ).alias("line")
     ).select("line")
     df_line.write_csv(file_path, include_header=False, quote_style="never")
+
+
+def nc_to_rows(
+    input: TextFileLike | str,
+    initial_state: TextFileLike | str | None = None,
+    axis_identifiers: list[str] | None = None,
+    extra_axes: list[str] | None = None,
+    iteration_limit: int = 10000,
+    forward_fill: bool = True,
+    include_variables: bool = False,
+    axis_index_map: dict[str, int] | None = None,
+    allow_undefined_variables: bool = False,
+):
+    """Interpret an NC program lazily, yielding one row at a time.
+
+    Returns an iterator of ``(line_no, row)`` tuples: the 1-based source
+    line the block came from (loops and jumps repeat / reorder line
+    numbers), and a dict of column values typed like the batch DataFrame
+    (``N``: int, ``M``: list[str], G-group/T/comment columns: str, axes and
+    other value columns: float). Rows are forward-filled like
+    :func:`nc_to_dataframe` unless ``forward_fill`` is False.
+
+    With ``include_variables=True`` the iterator yields ``(line_no, row,
+    variables)`` instead, where ``variables`` maps each variable the block
+    assigned (``R1=R1+1``, ``DEF REAL Q=5``, FOR counters) to its new float
+    value. Blocks that only assign variables — invisible in the batch
+    DataFrame and in the default stream — are then also yielded, with an
+    empty (never forward-filled) ``row``. Accumulating the ``variables``
+    dicts with ``dict.update`` reconstructs the full variable state at any
+    point of the stream.
+
+    The interpreter runs on a background thread behind a bounded channel:
+    rows arrive as they are produced, memory use is constant, and dropping
+    the iterator aborts interpretation. Breaking out of a ``for`` loop over
+    an anonymous iterator drops it; a stored iterator keeps the worker
+    alive (parked on the bounded channel) until it is deleted or
+    garbage-collected.
+    Errors raise ``ValueError`` from ``next()`` when reached. After the
+    iterator is exhausted, its ``state`` attribute holds the final
+    interpreter state (axes, symbol_table, translation).
+
+    Example:
+    --------
+    >>> for line_no, row in nc_to_rows("G1 X10\nX20 Y5"):
+    ...     print(line_no, row["X"])
+    1 10.0
+    2 20.0
+    >>> for line_no, row, variables in nc_to_rows("R1=5\nX=R1", include_variables=True):
+    ...     print(line_no, row.get("X"), variables)
+    1 None {'R1': 5.0}
+    2 5.0 {}
+    """
+    if input is None:
+        raise ValueError("input cannot be None")
+    if not isinstance(input, str):
+        input = input.read()
+    if initial_state is not None and not isinstance(initial_state, str):
+        initial_state = initial_state.read()
+    return _nc_to_rows(
+        input,
+        initial_state,
+        axis_identifiers,
+        extra_axes,
+        iteration_limit,
+        forward_fill,
+        include_variables,
+        axis_index_map,
+        allow_undefined_variables,
+    )

--- a/python/tests/test_streaming.py
+++ b/python/tests/test_streaming.py
@@ -1,0 +1,201 @@
+"""nc_to_rows: the streaming twin of nc_to_dataframe. Every program must
+yield exactly the batch DataFrame's rows, in order, with source line
+numbers attached."""
+
+import os
+import pathlib
+
+import polars as pl
+import pytest
+from nc_gcode_interpreter import nc_to_dataframe, nc_to_rows
+from polars.testing import assert_frame_equal
+
+
+def assert_stream_matches_batch(program, **kwargs):
+    df, state = nc_to_dataframe(program, **kwargs)
+    iterator = nc_to_rows(program, **kwargs)
+    rows = list(iterator)
+
+    assert len(rows) == df.height
+    streamed = pl.DataFrame(
+        [row for _line, row in rows],
+        schema={name: df.schema[name] for name in df.columns},
+    )
+    assert_frame_equal(df, streamed, check_column_order=False)
+    assert iterator.state["axes"] == state["axes"]
+    assert iterator.state["symbol_table"] == state["symbol_table"]
+    return rows
+
+
+@pytest.mark.parametrize(
+    "program",
+    [
+        "G1 X10\nX20 Y5 ; move\nM30",
+        "N10 X1.5 Y-2. Z0.001\nN20 X2 F2400 S8000 M3\n; comment only\nX3",
+        "BSPLINE\nX1 Y1 PW=1.5\nX2 Y2\nG1",
+        "GOTOF SKIP\nX999\nSKIP: X2",  # streamed through the line driver
+        "R1=0\nWHILE R1<3\nX=R1\nR1=R1+1\nENDWHILE\nM30",  # whole-file path
+        "DEF REAL D_VAL=2.5\nTRANS X10\nX1\nTRANS\nX2",
+        "X1\nM30\nX999",
+    ],
+    ids=lambda p: p.splitlines()[0][:25],
+)
+def test_stream_matches_batch(program):
+    assert_stream_matches_batch(program)
+
+
+def test_line_numbers_follow_execution_order():
+    program = "\n".join(
+        [
+            "R1=0",          # line 1
+            "WHILE R1<2",    # line 2
+            "X=R1",          # line 3
+            "R1=R1+1",       # line 4
+            "ENDWHILE",      # line 5
+            "X9",            # line 6
+        ]
+    )
+    rows = list(nc_to_rows(program))
+    lines = [line for line, _row in rows]
+    # The loop body executes twice: line 3 repeats (line 4 assigns a plain
+    # variable and therefore emits no output row).
+    assert lines == [3, 3, 6]
+
+
+def test_jump_line_numbers_are_source_positions():
+    rows = list(nc_to_rows("N10 X1\nGOTOF 40\nN30 X999\nN40 X4"))
+    assert [line for line, _row in rows] == [1, 4]
+
+
+def test_forward_fill_can_be_disabled():
+    rows = list(nc_to_rows("G1 X10\nY5", forward_fill=False))
+    assert "X" not in rows[1][1]
+    assert "gg01_motion" not in rows[1][1]
+
+
+def test_early_exit_does_not_hang():
+    iterator = nc_to_rows("X1\n" * 100_000)
+    for _ in range(3):
+        next(iterator)
+    del iterator  # must abort the worker without blocking
+
+
+def test_error_surfaces_at_the_offending_row():
+    iterator = nc_to_rows("X1\nX2\nX=UNDEFINED_VAR")
+    assert next(iterator)[0] == 1
+    assert next(iterator)[0] == 2
+    with pytest.raises(ValueError, match="UNDEFINED_VAR"):
+        next(iterator)
+
+
+def test_parse_error_raises_before_first_row():
+    iterator = nc_to_rows("X1\nIF R1>0\nX2")
+    with pytest.raises(ValueError, match="IF is never closed"):
+        next(iterator)
+
+
+def test_state_is_none_until_exhausted():
+    iterator = nc_to_rows("X1\nX2")
+    assert iterator.state is None
+    list(iterator)
+    assert iterator.state["axes"] == {"X": 2.0}
+
+
+def test_initial_state_rows_are_not_streamed():
+    rows = list(nc_to_rows("X1", initial_state="Y99\nDEF REAL Q=1"))
+    assert len(rows) == 1
+    assert rows[0][1]["X"] == 1.0
+    assert "Y" not in rows[0][1]  # initial-state moves set state, not rows
+
+
+def test_include_variables_exposes_assignments():
+    program = "\n".join(
+        [
+            "DEF REAL Q=2.5",  # line 1: definition, no output cells
+            "R1=0",            # line 2: variable-only
+            "WHILE R1<2",      # line 3
+            "X=R1",            # line 4: output row, no variable change
+            "R1=R1+1",         # line 5: variable-only, twice
+            "ENDWHILE",        # line 6
+            "X=Q",             # line 7
+        ]
+    )
+    rows = list(nc_to_rows(program, include_variables=True))
+    assert [(line, vars) for line, _row, vars in rows] == [
+        (1, {"Q": 2.5}),
+        (2, {"R1": 0.0}),
+        (4, {}),
+        (5, {"R1": 1.0}),
+        (4, {}),
+        (5, {"R1": 2.0}),
+        (7, {}),
+    ]
+    # Variable-only blocks yield an empty, never forward-filled row dict.
+    assert rows[0][1] == {}
+    assert rows[3][1] == {}
+    assert rows[2][1]["X"] == 0.0
+    assert rows[6][1]["X"] == 2.5
+
+
+def test_include_variables_covers_def_multi_and_for_counter():
+    program = "\n".join(
+        [
+            "DEF REAL QA, QB[2]",           # bare defs initialize to 0
+            "DEF REAL QC[3]=SET(1,,3)",     # gap: QC[1] stays untouched
+            "FOR R7=1 TO 2",
+            "X=R7",
+            "ENDFOR",
+        ]
+    )
+    rows = list(nc_to_rows(program, include_variables=True))
+    variables = [(line, vars) for line, _row, vars in rows]
+    assert variables[0] == (1, {"QA": 0.0, "QB[0]": 0.0, "QB[1]": 0.0, "QB[2]": 0.0})
+    assert variables[1] == (2, {"QC[0]": 1.0, "QC[2]": 3.0})
+    assert variables[2] == (3, {"R7": 1.0})  # FOR init on the FOR line
+    # Counter increments surface on the ENDFOR line, where the control
+    # performs them; the X=R7 body rows in between carry no changes.
+    assert variables[3] == (4, {})
+    assert variables[4] == (5, {"R7": 2.0})
+    assert variables[5] == (4, {})
+    assert variables[6] == (5, {"R7": 3.0})
+
+
+def test_accumulated_variables_match_final_state():
+    program = "\n".join(
+        [
+            "DEF REAL Q=1",
+            "R1=0",
+            "WHILE R1<3",
+            "X=R1 Q=Q*2",
+            "R1=R1+1",
+            "ENDWHILE",
+        ]
+    )
+    iterator = nc_to_rows(program, include_variables=True)
+    accumulated = {}
+    for _line, _row, variables in iterator:
+        accumulated.update(variables)
+    symbol_table = dict(iterator.state["symbol_table"])
+    for name in ("TRUE", "FALSE"):  # built-ins, never assigned by the program
+        symbol_table.pop(name)
+    assert accumulated == symbol_table
+
+
+def test_include_variables_off_keeps_two_tuples_and_hides_variable_rows():
+    rows = list(nc_to_rows("R1=5\nX=R1"))
+    assert rows == [(2, {"X": 5.0})]
+
+
+MILL_SIM = pathlib.Path(
+    # Override with NC_TEST_CORPUS to run the corpus test elsewhere; it is
+    # skipped when the directory does not exist.
+    os.environ.get("NC_TEST_CORPUS", "/Users/thijsdamsma/projects/mill-sim/test-case-1")
+)
+
+
+@pytest.mark.skipif(not MILL_SIM.exists(), reason="mill-sim corpus not available")
+def test_stream_matches_batch_on_real_program():
+    program = (MILL_SIM / "Test Sheffield_ROUGHmpf.mpf").read_text(errors="replace")
+    assert_stream_matches_batch(
+        program, extra_axes=["ELX"], allow_undefined_variables=True
+    )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,6 +69,8 @@ Details: {message}
     UnexpectedOperator { operator: String },
     #[error("Loop limit of {limit} reached")]
     LoopLimit { limit: String },
+    #[error("row stream closed by the consumer")]
+    StreamClosed,
     #[error(r#"
 Too many M commands in a single block on line {line_no}
 ----------------------------------------

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -5,7 +5,7 @@ use crate::types::Rule;
 use crate::types::Value;
 use std::collections::HashMap;
 
-type Output = Vec<HashMap<String, Value>>;
+type Output = crate::output::OutputRows;
 
 /// Control-flow signal returned by block interpretation: either fall through
 /// to the next block, or a pending GOTO that must be resolved against the
@@ -696,7 +696,9 @@ fn interpret_axis_increment(pair: Pair<Rule>, state: &mut State, key: String) ->
         }
     }
 }
-fn interpret_assignment_multi(element: Pair<Rule>, state: &mut State) -> Result<Vec<String>, ParsingError> {
+/// Returns each target key with the value assigned to it, or `None` for
+/// keys a gap in the value array left untouched.
+fn interpret_assignment_multi(element: Pair<Rule>, state: &mut State) -> Result<Vec<(String, Option<f64>)>, ParsingError> {
     // assignment_multi =  { variable_array ~ "=" ~ (value_array | value_repeating) }
     let mut inner_pairs = element.into_inner();
     let variable_pair = inner_pairs
@@ -714,14 +716,17 @@ fn interpret_assignment_multi(element: Pair<Rule>, state: &mut State) -> Result<
             actual: values.len(),
         });
     }
-    for (i, key) in keys.iter().enumerate() {
-        if let Some(value) = values.get(i).cloned().flatten() {
-            state.symbol_table.insert(key.clone(), value);
-        } else {
-            // do nothing, the value is not set
-        }
-    }
-    Ok(keys)
+    Ok(keys
+        .into_iter()
+        .enumerate()
+        .map(|(i, key)| {
+            let value = values.get(i).copied().flatten();
+            if let Some(value) = value {
+                state.symbol_table.insert(key.clone(), value);
+            }
+            (key, value)
+        })
+        .collect())
 }
 fn interpret_value_array(pair: Pair<Rule>, state: &mut State) -> Result<Vec<Option<f64>>, ParsingError> {
     let mut values = Vec::new();
@@ -855,7 +860,7 @@ fn interpret_identifier(pair: Pair<Rule>) -> Result<String, ParsingError> {
         })
     }
 }
-fn interpret_definition(element: Pair<Rule>, state: &mut State) -> Result<(), ParsingError> {
+fn interpret_definition(element: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<(), ParsingError> {
     let pairs = element.into_inner();
     for pair in pairs {
         match pair.as_rule() {
@@ -866,9 +871,14 @@ fn interpret_definition(element: Pair<Rule>, state: &mut State) -> Result<(), Pa
                 } else if state.is_block_address(res.0.as_str()) {
                     return Err(ParsingError::ReservedNameUsedAsVariable { name: res.0 });
                 }
+                output.record_variable_change(&res.0, res.1);
             }
             Rule::assignment_multi => {
-                interpret_assignment_multi(pair, state)?;
+                for (key, value) in interpret_assignment_multi(pair, state)? {
+                    if let Some(value) = value {
+                        output.record_variable_change(&key, value);
+                    }
+                }
             }
             Rule::variable => {
                 let key = interpret_variable(pair, state)?;
@@ -877,12 +887,14 @@ fn interpret_definition(element: Pair<Rule>, state: &mut State) -> Result<(), Pa
                 } else if state.is_block_address(&key) {
                     return Err(ParsingError::ReservedNameUsedAsVariable { name: key });
                 }
-                state.symbol_table.insert(key, 0.0);
+                state.symbol_table.insert(key.clone(), 0.0);
+                output.record_variable_change(&key, 0.0);
             }
             Rule::variable_array => {
                 let keys = interpret_variable_array(pair, state)?;
                 for key in keys {
-                    state.symbol_table.insert(key, 0.0);
+                    state.symbol_table.insert(key.clone(), 0.0);
+                    output.record_variable_change(&key, 0.0);
                 }
             }
             Rule::data_type => {
@@ -1087,7 +1099,8 @@ fn interpret_statement_for(
 
     // Parse and execute the assignment statement
     let assignment = pairs.next().expect("Expected an assignment, got none");
-    let (variable_name, _) = interpret_assignment(assignment, state)?;
+    let (variable_name, initial_value) = interpret_assignment(assignment, state)?;
+    output.record_variable_change(&variable_name, initial_value);
 
     // Evaluate the TO expression to determine the loop's end value
     let to_expression = pairs.next().expect("Expected a TO expression, got none");
@@ -1118,6 +1131,11 @@ fn interpret_statement_for(
                 .get_mut(&variable_name)
                 .expect("Variable should exist");
             *loop_control_value += 1.0; // Increment value directly
+            let new_value = *loop_control_value;
+            // Recorded on the row current at this point: the ENDFOR line,
+            // whose (otherwise empty) block is the loop body's last row -
+            // exactly where the control performs the increment.
+            output.record_variable_change(&variable_name, new_value);
         }
     }
     Ok(BlockFlow::Continue)
@@ -1475,6 +1493,8 @@ fn interpret_statement(
                     last.insert(key, Value::Float(machine_value));
                 } else if state.is_block_address(&key) {
                     last.insert(key, Value::Float(local_value));
+                } else {
+                    output.record_variable_change(&key, local_value);
                 }
             }
             Rule::tool_selection => interpret_tool_selection(statement, output, state)?,
@@ -1608,8 +1628,8 @@ pub(crate) fn interpret_block(
 ) -> Result<BlockFlow, ParsingError> {
     match element.as_rule() {
         Rule::block => {
-            // Create a new HashMap for this block
-            output.push(HashMap::new());
+            // Start this block's output row, flushing the previous one.
+            output.start_row(element.line_col().0)?;
 
             let mut flow = BlockFlow::Continue;
             for item in element.into_inner() {
@@ -1624,7 +1644,7 @@ pub(crate) fn interpret_block(
                     // execution; at execution time they are inert.
                     Rule::label_def => {}
                     Rule::control => flow = interpret_control(item, output, state)?,
-                    Rule::definition => interpret_definition(item, state)?,
+                    Rule::definition => interpret_definition(item, output, state)?,
                     Rule::frame_op => interpret_frame_op(item, state)?,
                     Rule::comment => {
                         let last = output.last_mut().expect("Output vector should not be empty");

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,9 +1,9 @@
 //interpreter.rs
 use crate::errors::ParsingError;
 use crate::interpret_rules::{interpret_blocks, BlockFlow};
-use crate::output::Table;
+use crate::output::{OutputRows, Row, Table};
 use crate::state::{self, State};
-use crate::types::{NCParser, Rule, Value};
+use crate::types::{NCParser, Rule};
 use pest::Parser;
 use std::collections::HashMap;
 
@@ -22,46 +22,87 @@ pub fn nc_to_table(
     axis_index_map: Option<HashMap<String, usize>>, // axis identifier to index mapping
     allow_undefined_variables: bool,
 ) -> Result<(Table, state::State), ParsingError> {
-    // Use the override if provided, otherwise use the default identifiers
-    let axis_identifiers: Vec<String> =
-        axis_identifiers.unwrap_or_else(|| DEFAULT_AXIS_IDENTIFIERS.iter().map(|&s| s.to_string()).collect());
-
-    // Add extra axes to the existing list if provided
-    let mut axis_identifiers = axis_identifiers;
-    if let Some(extra_axes) = extra_axes {
-        axis_identifiers.extend(extra_axes);
-    }
-
-    let mut state = state::State::new(
-        axis_identifiers.clone(),
+    let mut state = build_state(
+        axis_identifiers,
+        extra_axes,
         iteration_limit,
         axis_index_map,
         allow_undefined_variables,
     );
     if let Some(initial_state) = initial_state {
         // Propagate the error instead of exiting: this is library code, and
-        // process::exit would kill e.g. a host Python interpreter.
-        interpret_file(initial_state, &mut state)?;
+        // process::exit would kill e.g. a host Python interpreter. The rows
+        // of the initial-state file are discarded; only the state matters.
+        let mut discard = OutputRows::collect();
+        interpret_file(initial_state, &mut state, &mut discard)?;
     }
 
     // Now interpret the main input using the axis_index_map from state
-    let results = interpret_file(input, &mut state)?;
+    let mut output = OutputRows::collect();
+    interpret_file(input, &mut state, &mut output)?;
+    let rows = output.finish()?;
 
-    let table = Table::from_rows(&results, disable_forward_fill);
+    let table = Table::from_rows(&rows, disable_forward_fill);
     Ok((table, state))
 }
 
-/// Parse file and return results as a vector of HashMaps
-fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, Value>>, ParsingError> {
+fn build_state(
+    axis_identifiers: Option<Vec<String>>,
+    extra_axes: Option<Vec<String>>,
+    iteration_limit: usize,
+    axis_index_map: Option<HashMap<String, usize>>,
+    allow_undefined_variables: bool,
+) -> State {
+    // Use the override if provided, otherwise use the default identifiers
+    let mut axis_identifiers: Vec<String> =
+        axis_identifiers.unwrap_or_else(|| DEFAULT_AXIS_IDENTIFIERS.iter().map(|&s| s.to_string()).collect());
+    if let Some(extra_axes) = extra_axes {
+        axis_identifiers.extend(extra_axes);
+    }
+    state::State::new(axis_identifiers, iteration_limit, axis_index_map, allow_undefined_variables)
+}
+
+/// Streaming twin of `nc_to_table`: interpret the program pushing each
+/// finished row into `sender` as `(line_no, row)`, returning the final
+/// state. Blocks on the channel when the consumer is slower than the
+/// interpreter; aborts with `StreamClosed` when the consumer hangs up.
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // used by the python-feature bindings, not the bin
+pub fn nc_to_row_stream(
+    input: &str,
+    initial_state: Option<&str>,
+    axis_identifiers: Option<Vec<String>>,
+    extra_axes: Option<Vec<String>>,
+    iteration_limit: usize,
+    axis_index_map: Option<HashMap<String, usize>>,
+    allow_undefined_variables: bool,
+    sender: std::sync::mpsc::SyncSender<Row>,
+) -> Result<state::State, ParsingError> {
+    let mut state = build_state(
+        axis_identifiers,
+        extra_axes,
+        iteration_limit,
+        axis_index_map,
+        allow_undefined_variables,
+    );
+    if let Some(initial_state) = initial_state {
+        let mut discard = OutputRows::collect();
+        interpret_file(initial_state, &mut state, &mut discard)?;
+    }
+    let mut output = OutputRows::stream(sender);
+    interpret_file(input, &mut state, &mut output)?;
+    output.finish()?;
+    Ok(state)
+}
+
+/// Interpret a file, pushing rows into `output`.
+fn interpret_file(input: &str, state: &mut State, output: &mut OutputRows) -> Result<(), ParsingError> {
     // Store input for error messages
     state.set_input(input.to_string());
 
     // Validate control-structure nesting first: a PEG reports an unclosed
     // IF/WHILE at the end of the file; the line scan reports the opener.
     let shape = crate::structure_scan::check_structures(input)?;
-
-    // Initialize results with an empty HashMap
-    let mut results = vec![HashMap::new()];
 
     // Stage-1 fast path: structure-free programs (all CAM output) are
     // interpreted line by line - trivial lines through the byte decoder,
@@ -70,8 +111,8 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
         let mut padded_lines = Vec::new();
         // None: the line driver declined (padding budget); fall through to
         // the whole-file parse below.
-        match crate::line_driver::interpret_lines(input, &mut padded_lines, &mut results, state)? {
-            Some(BlockFlow::Continue) | Some(BlockFlow::EndProgram) => return Ok(results),
+        match crate::line_driver::interpret_lines(input, &mut padded_lines, output, state)? {
+            Some(BlockFlow::Continue) | Some(BlockFlow::EndProgram) => return Ok(()),
             Some(BlockFlow::Jump(request)) => return Err(request.into_not_found_error(state)),
             None => {}
         }
@@ -98,8 +139,8 @@ fn interpret_file(input: &str, state: &mut State) -> Result<Vec<HashMap<String, 
             message: "No inner blocks found".to_string(),
         })?;
 
-    match interpret_blocks(blocks, &mut results, state)? {
-        BlockFlow::Continue | BlockFlow::EndProgram => Ok(results),
+    match interpret_blocks(blocks, output, state)? {
+        BlockFlow::Continue | BlockFlow::EndProgram => Ok(()),
         // A jump that no scope could resolve: the destination does not exist
         // in the programmed search direction (alarm 14080 on a real control).
         BlockFlow::Jump(request) => Err(request.into_not_found_error(state)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,14 @@ mod structure_scan;
 mod python_bindings {
     use pyo3::exceptions::PyValueError;
     use pyo3::prelude::*;
-    use pyo3::types::PyDict;
+    use pyo3::types::{PyDict, PyList};
     use pyo3::wrap_pyfunction;
     use std::collections::HashMap;
+    use std::sync::{mpsc, Mutex};
 
-    use crate::interpreter::nc_to_table;
-    use crate::output::Column;
+    use crate::interpreter::{nc_to_row_stream, nc_to_table};
+    use crate::output::{is_forward_filled_column, is_string_column, Column};
+    use crate::types::Value;
 
     /// Interpret an NC program and return plain columnar data:
     /// (data: dict[str, list], schema: list[(name, dtype)], state: dict).
@@ -72,10 +74,234 @@ mod python_bindings {
         Ok((data.into(), schema, state.to_python_dict()))
     }
 
+    type FinalState = HashMap<String, HashMap<String, f64>>;
+
+    /// Iterator over interpreted rows: `next()` yields
+    /// `(line_no, {column: value})` while the interpreter runs on a worker
+    /// thread behind a bounded channel. Dropping the iterator hangs up the
+    /// channel and aborts interpretation; note that in Python, breaking out
+    /// of a loop only drops it when no other reference keeps it alive.
+    #[pyclass]
+    struct NcRowIterator {
+        rows: Option<Mutex<mpsc::Receiver<crate::output::Row>>>,
+        result: Option<Mutex<mpsc::Receiver<Result<FinalState, String>>>>,
+        handle: Option<std::thread::JoinHandle<()>>,
+        /// Running forward-fill values, keyed by column.
+        fill: HashMap<String, Value>,
+        forward_fill: bool,
+        include_variables: bool,
+        state: Option<FinalState>,
+    }
+
+    impl NcRowIterator {
+        /// Convert one cell with the same name-based typing as the batch
+        /// table (N: int, M: list[str], string columns: str, rest: float).
+        fn cell_to_py(py: Python<'_>, name: &str, value: &Value) -> PyResult<Py<PyAny>> {
+            let object = if name == "N" {
+                match value {
+                    Value::Str(s) => s
+                        .parse::<i64>()
+                        .ok()
+                        .or_else(|| s.parse::<f64>().ok().map(|v| v as i64))
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind(),
+                    Value::Float(f) => (*f as i64).into_pyobject(py)?.into_any().unbind(),
+                    Value::StrList(l) => PyList::new(py, l)?.into_any().unbind(),
+                }
+            } else if name == "M" {
+                match value {
+                    Value::StrList(l) => PyList::new(py, l)?.into_any().unbind(),
+                    Value::Str(s) => PyList::new(py, [s])?.into_any().unbind(),
+                    Value::Float(f) => PyList::new(py, [f.to_string()])?.into_any().unbind(),
+                }
+            } else if is_string_column(name) {
+                match value {
+                    Value::Str(s) => s.into_pyobject(py)?.into_any().unbind(),
+                    Value::Float(f) => f.to_string().into_pyobject(py)?.into_any().unbind(),
+                    Value::StrList(l) => PyList::new(py, l)?.into_any().unbind(),
+                }
+            } else {
+                match value {
+                    Value::Float(f) => f.into_pyobject(py)?.into_any().unbind(),
+                    Value::Str(s) => s.parse::<f64>().ok().into_pyobject(py)?.into_any().unbind(),
+                    Value::StrList(l) => PyList::new(py, l)?.into_any().unbind(),
+                }
+            };
+            Ok(object)
+        }
+
+        fn finish(&mut self, py: Python<'_>) -> PyResult<()> {
+            if let Some(result) = self.result.take() {
+                let receiver = result.into_inner().expect("result receiver mutex poisoned");
+                match py.detach(move || receiver.recv()) {
+                    Ok(Ok(state)) => self.state = Some(state),
+                    Ok(Err(message)) => {
+                        self.join();
+                        return Err(PyErr::new::<PyValueError, _>(message));
+                    }
+                    Err(_) => {}
+                }
+            }
+            self.join();
+            Ok(())
+        }
+
+        fn join(&mut self) {
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    #[pymethods]
+    impl NcRowIterator {
+        fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+            slf
+        }
+
+        fn __next__(&mut self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+            loop {
+                let Some(mutex) = self.rows.take() else {
+                    return Ok(None);
+                };
+                // The receiver moves into the detached closure (an owned
+                // Receiver is Send) and back out, releasing the GIL while
+                // blocked on the channel.
+                let receiver = mutex.into_inner().expect("row receiver mutex poisoned");
+                let (received, receiver) = py.detach(move || {
+                    let received = receiver.recv();
+                    (received, receiver)
+                });
+                if received.is_ok() {
+                    self.rows = Some(Mutex::new(receiver));
+                }
+                match received {
+                    Ok(row) => {
+                        // Blocks that only assigned variables have no output
+                        // cells; the batch table drops them, so the default
+                        // stream does too.
+                        if row.cells.is_empty() && !self.include_variables {
+                            continue;
+                        }
+                        let dict = PyDict::new(py);
+                        // A variable-only row stays an empty dict: it is a
+                        // state event, not an output row, so it is not
+                        // forward-filled into a fake duplicate of the
+                        // previous position.
+                        if !row.cells.is_empty() {
+                            if self.forward_fill {
+                                for (key, value) in &row.cells {
+                                    if is_forward_filled_column(key) {
+                                        self.fill.insert(key.clone(), value.clone());
+                                    }
+                                }
+                            }
+                            // Forward-filled columns first, then the row's own
+                            // values (its fillable ones are already in `fill`).
+                            for (key, value) in &self.fill {
+                                dict.set_item(key, Self::cell_to_py(py, key, value)?)?;
+                            }
+                            for (key, value) in &row.cells {
+                                if !self.forward_fill || !is_forward_filled_column(key) {
+                                    dict.set_item(key, Self::cell_to_py(py, key, value)?)?;
+                                }
+                            }
+                        }
+                        let item = if self.include_variables {
+                            // Last write wins when a block assigns the same
+                            // variable twice; replaying these dicts row by row
+                            // reconstructs the symbol table at any point.
+                            let variables = PyDict::new(py);
+                            for (key, value) in &row.variable_changes {
+                                variables.set_item(key, *value)?;
+                            }
+                            (row.line_no, dict, variables).into_pyobject(py)?.into_any().unbind()
+                        } else {
+                            (row.line_no, dict).into_pyobject(py)?.into_any().unbind()
+                        };
+                        return Ok(Some(item));
+                    }
+                    // Channel closed: interpretation finished (or failed).
+                    Err(_) => {
+                        self.rows = None;
+                        self.finish(py)?;
+                        return Ok(None);
+                    }
+                }
+            }
+        }
+
+        /// The final interpreter state (axes, symbol_table, translation),
+        /// available once the iterator is exhausted.
+        #[getter]
+        fn state(&self) -> Option<FinalState> {
+            self.state.clone()
+        }
+    }
+
+    /// Interpret an NC program lazily: returns an iterator of
+    /// `(line_no, row_dict)` — or `(line_no, row_dict, variables_dict)` when
+    /// `include_variables` is set — produced by the interpreter running on a
+    /// worker thread. Rows are forward-filled like the batch DataFrame
+    /// unless `forward_fill` is false.
+    #[pyfunction]
+    #[pyo3(signature = (input, initial_state = None, axis_identifiers = None, extra_axes = None, iteration_limit = 10000, forward_fill = true, include_variables = false, axis_index_map = None, allow_undefined_variables = false))]
+    #[allow(clippy::too_many_arguments)]
+    fn nc_to_rows(
+        input: String,
+        initial_state: Option<String>,
+        axis_identifiers: Option<Vec<String>>,
+        extra_axes: Option<Vec<String>>,
+        iteration_limit: usize,
+        forward_fill: bool,
+        include_variables: bool,
+        axis_index_map: Option<HashMap<String, usize>>,
+        allow_undefined_variables: bool,
+    ) -> PyResult<NcRowIterator> {
+        let (row_sender, row_receiver) = mpsc::sync_channel::<crate::output::Row>(1024);
+        let (result_sender, result_receiver) = mpsc::sync_channel::<Result<FinalState, String>>(1);
+
+        let handle = std::thread::Builder::new()
+            .name("nc-interpreter".to_string())
+            .spawn(move || {
+                let outcome = nc_to_row_stream(
+                    &input,
+                    initial_state.as_deref(),
+                    axis_identifiers,
+                    extra_axes,
+                    iteration_limit,
+                    axis_index_map,
+                    allow_undefined_variables,
+                    row_sender,
+                );
+                let message = match outcome {
+                    Ok(state) => Ok(state.to_python_dict()),
+                    // The consumer hung up: nothing to report to nobody.
+                    Err(crate::errors::ParsingError::StreamClosed) => return,
+                    Err(error) => Err(format!("{}", error)),
+                };
+                let _ = result_sender.send(message);
+            })
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("failed to spawn interpreter thread: {}", e)))?;
+
+        Ok(NcRowIterator {
+            rows: Some(Mutex::new(row_receiver)),
+            result: Some(Mutex::new(result_receiver)),
+            handle: Some(handle),
+            fill: HashMap::new(),
+            forward_fill,
+            include_variables,
+            state: None,
+        })
+    }
+
     /// Define the Python module
     #[pymodule(name = "_internal")]
     pub fn nc_gcode_interpreter(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_function(wrap_pyfunction!(nc_to_columns, m)?)?;
+        m.add_function(wrap_pyfunction!(nc_to_rows, m)?)?;
+        m.add_class::<NcRowIterator>()?;
         Ok(())
     }
 }

--- a/src/line_driver.rs
+++ b/src/line_driver.rs
@@ -31,7 +31,7 @@ use crate::types::{NCParser, Pair, Rule, Value};
 use pest::Parser;
 use std::collections::HashMap;
 
-type Output = Vec<HashMap<String, Value>>;
+type Output = crate::output::OutputRows;
 
 /// One word of a decoded trivial line, in source order.
 enum Word {
@@ -191,7 +191,7 @@ fn execute_decoded(line: &DecodedLine, output: &mut Output, state: &mut State) -
     if !line.has_content {
         return Ok(BlockFlow::Continue);
     }
-    output.push(HashMap::new());
+    output.start_row(line.line_no)?;
     let mut flow = BlockFlow::Continue;
     // Split borrows: row insertion vs axis-state updates.
     for word in &line.words {
@@ -206,6 +206,7 @@ fn execute_decoded(line: &DecodedLine, output: &mut Output, state: &mut State) -
                     last.insert(key.clone(), Value::Float(*value));
                 } else {
                     state.symbol_table.insert(key.clone(), *value);
+                    output.record_variable_change(key, *value);
                 }
             }
             Word::GCommand(group, as_written) => {

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,10 +6,111 @@
 //! turns it into a polars DataFrame on the Python side, and the CLI writes
 //! CSV directly with the `csv` crate.
 
+use crate::errors::ParsingError;
 use crate::modal_groups::{MODAL_G_GROUPS, NON_MODAL_G_GROUPS};
 use crate::state::BLOCK_ADDRESSES;
 use crate::types::Value;
 use std::collections::{HashMap, HashSet};
+
+/// One interpreter output row: the source line it came from, the values the
+/// block produced, and the variables the block assigned. Loops and jumps emit
+/// repeated / non-monotonic line numbers - exactly what a visualizer needs to
+/// map trace rows to source.
+#[derive(Debug, Default, Clone)]
+pub struct Row {
+    pub line_no: usize,
+    pub cells: HashMap<String, Value>,
+    /// Variable assignments this block performed (`R1=R1+1`, `DEF REAL Q=5`,
+    /// FOR-loop counter updates), in program order with repeats preserved.
+    /// Replaying `variable_changes` row by row reconstructs the symbol table
+    /// as it stood at any point of the stream; the batch table ignores them.
+    pub variable_changes: Vec<(String, f64)>,
+}
+
+/// Where finished rows go: collected for the batch table, or pushed into a
+/// bounded channel that a streaming consumer drains while interpretation is
+/// still running.
+enum RowSink {
+    Collect(Vec<Row>),
+    #[allow(dead_code)] // constructed by the python-feature bindings, not the bin
+    Stream(std::sync::mpsc::SyncSender<Row>),
+}
+
+/// The interpreter's output handle. A block starts a row with `start_row`;
+/// statements fill it via `last_mut`; starting the next row (or finishing)
+/// flushes the previous one to the sink. Empty rows - blocks that only
+/// affected internal state - are dropped at flush time, mirroring the old
+/// whole-table pruning.
+pub struct OutputRows {
+    current: Row,
+    sink: RowSink,
+}
+
+impl OutputRows {
+    pub fn collect() -> Self {
+        OutputRows {
+            current: Row::default(),
+            sink: RowSink::Collect(Vec::new()),
+        }
+    }
+
+    #[allow(dead_code)] // used by the python-feature bindings, not the bin
+    pub fn stream(sender: std::sync::mpsc::SyncSender<Row>) -> Self {
+        OutputRows {
+            current: Row::default(),
+            sink: RowSink::Stream(sender),
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), ParsingError> {
+        if self.current.cells.is_empty() && self.current.variable_changes.is_empty() {
+            return Ok(());
+        }
+        let row = std::mem::take(&mut self.current);
+        match &mut self.sink {
+            RowSink::Collect(rows) => {
+                rows.push(row);
+                Ok(())
+            }
+            // The receiver hung up: the consumer stopped iterating. Abort
+            // interpretation instead of running the rest of the program.
+            RowSink::Stream(sender) => sender.send(row).map_err(|_| ParsingError::StreamClosed),
+        }
+    }
+
+    /// Begin the row for the block at `line_no`, flushing the previous row.
+    pub fn start_row(&mut self, line_no: usize) -> Result<(), ParsingError> {
+        self.flush()?;
+        self.current.line_no = line_no;
+        Ok(())
+    }
+
+    /// The row currently being filled. Named after `Vec::last_mut`, which
+    /// this type replaced; always `Some`.
+    pub fn last_mut(&mut self) -> Option<&mut HashMap<String, Value>> {
+        Some(&mut self.current.cells)
+    }
+
+    /// Record a variable assignment on the row currently being filled.
+    /// Only the streaming iterator consumes variable deltas, so this is a
+    /// no-op in collect mode: the batch path keeps pruning variable-only
+    /// rows at flush and carries no delta allocations.
+    pub fn record_variable_change(&mut self, key: &str, value: f64) {
+        if matches!(self.sink, RowSink::Stream(_)) {
+            self.current.variable_changes.push((key.to_string(), value));
+        }
+    }
+
+    /// Flush the trailing row and return the collected rows (empty when
+    /// streaming).
+    pub fn finish(mut self) -> Result<Vec<Row>, ParsingError> {
+        self.flush()?;
+        Ok(match self.sink {
+            RowSink::Collect(rows) => rows,
+            RowSink::Stream(_) => Vec::new(),
+        })
+    }
+}
 
 /// A single typed column. Values are optional: `None` is a null cell.
 #[derive(Debug, Clone, PartialEq)]
@@ -77,10 +178,19 @@ const KNOWN_AXIS_COLUMNS: &[&str] = &[
     "X", "Y", "Z", "A", "B", "C", "D", "E", "F", "S", "U", "V", "RA1", "RA2", "RA3", "RA4", "RA5", "RA6",
 ];
 
-fn is_string_column(name: &str) -> bool {
+pub fn is_string_column(name: &str) -> bool {
     MODAL_G_GROUPS.contains(&name)
         || NON_MODAL_G_GROUPS.contains(&name)
         || matches!(name, "T" | "non_returning_function_call" | "comment")
+}
+
+/// Whether a column is forward-filled in the sanitized table: value columns
+/// (anything typed numeric by name, except the spline block addresses) and
+/// the modal G-group columns. Shared by the batch table and the streaming
+/// iterator so both fill identically.
+pub fn is_forward_filled_column(name: &str) -> bool {
+    let is_value = name != "M" && !is_string_column(name) && !BLOCK_ADDRESSES.contains(&name);
+    is_value || MODAL_G_GROUPS.contains(&name)
 }
 
 impl Table {
@@ -88,10 +198,11 @@ impl Table {
     /// canonical order (N, G-group columns, axes, other value columns, T, M,
     /// function calls, comment), with axis and modal G-group columns
     /// forward-filled unless disabled.
-    pub fn from_rows(rows: &[HashMap<String, Value>], disable_forward_fill: bool) -> Table {
-        // Skip rows that carry no values at all (blocks that only affected
-        // internal state, e.g. definitions).
-        let rows: Vec<&HashMap<String, Value>> = rows.iter().filter(|r| !r.is_empty()).collect();
+    pub fn from_rows(rows: &[Row], disable_forward_fill: bool) -> Table {
+        // Skip rows that carry no output values (blocks that only affected
+        // internal state, e.g. definitions - their variable_changes are a
+        // streaming-only concern).
+        let rows: Vec<&HashMap<String, Value>> = rows.iter().map(|r| &r.cells).filter(|r| !r.is_empty()).collect();
 
         let present: HashSet<&str> = rows.iter().flat_map(|r| r.keys().map(|k| k.as_str())).collect();
 
@@ -132,19 +243,12 @@ impl Table {
             push_if_present(name, &mut ordered);
         }
 
-        // The forward-fill set: value columns (axes, block numbers - anything
-        // that is not a known string/list column) plus the modal G-group
-        // columns, matching the previous DataFrame sanitization.
-        let modal: HashSet<&str> = MODAL_G_GROUPS.iter().copied().collect();
-
         let mut columns: Vec<(String, Column)> = Vec::with_capacity(ordered.len());
         for name in ordered {
             let mut column = build_column(&name, &rows);
             // Block addresses (spline PW/SD/PL) are never forward-filled: a
             // point weight applies only to the point it is programmed with.
-            let is_value_column = matches!(column, Column::Float(_) | Column::Int(_))
-                && !BLOCK_ADDRESSES.contains(&name.as_str());
-            if !disable_forward_fill && (is_value_column || modal.contains(name.as_str())) {
+            if !disable_forward_fill && is_forward_filled_column(&name) {
                 column.forward_fill();
             }
             columns.push((name, column));


### PR DESCRIPTION
Stacked on #34 — the final phase of the plan (PR E), and the piece the robot-cell simulator / visualizer work pulls on.

## API

```python
from nc_gcode_interpreter import nc_to_rows

for line_no, row in nc_to_rows(program, extra_axes=["ELX"]):
    ...            # row: {"X": 10.0, "gg01_motion": "G1", ...}, forward-filled
it = nc_to_rows(program)
next(it)           # rows arrive while the interpreter is still running
del it             # breaking out / dropping aborts interpretation
it.state           # final axes/symbol_table/translation after exhaustion
```

- `line_no` is the 1-based source line of the block — loops and jumps repeat/reorder line numbers, giving the visualizer trace→source highlighting for free.
- Cells are typed like the batch DataFrame (`N` int, `M` list[str], G-group/T/comment str, values float) and forward-filled with the *same* column rules (shared `is_forward_filled_column`).
- Errors raise from `next()` at the offending row; parse/structure errors before the first row (eager validation is kept).

## Implementation

`OutputRows` replaces the `Vec<HashMap>` output: blocks start rows with `start_row(line_no)`, flushing the previous row to a sink — collected for the batch table, or pushed into a bounded `sync_channel(1024)` drained by a pyo3 iterator (`__iter__`/`__next__`, GIL released while blocked) with the interpreter on a named worker thread. Consumer hang-up surfaces as `ParsingError::StreamClosed` and aborts the run. Empty rows are dropped at flush, mirroring the old whole-table pruning. Both execution paths (line driver and whole-file) stream identically.

## Numbers (real-world 21 MB (319k-line) program)

| | batch `nc_to_dataframe` | `nc_to_rows` |
|---|---|---|
| first row | ~10 s (whole table) | **~1.6 s** (after eager validation) |
| full drain | ~10 s | ~8.6 s |
| memory | full table | constant |

## Variable insight (`include_variables=True`)

`nc_to_rows(..., include_variables=True)` yields `(line_no, row, variables)`: every variable assignment a block performs (plain assignments, `DEF` initializations, `SET`/`REP` multi-assignments, FOR counters — the increment surfaces on the ENDFOR line, where the control performs it) arrives as a per-row delta, and variable-only blocks — pruned from the batch DataFrame — are streamed too, with an empty row dict. Accumulating the deltas with `dict.update` reconstructs the symbol table at any row; a live query of the worker's state would race against the channel buffer, so deltas ride on the rows instead. `Row` grows from a tuple into a struct carrying `variable_changes`; the batch table ignores them, so `nc_to_dataframe` and CLI output are byte-identical.

## Verification

`test_streaming.py`: streamed rows reconstruct the batch DataFrame exactly (assert_frame_equal) across both execution paths, jumps, loops, M30-mid-file, initial-state isolation, and a real corpus program; plus early-exit-no-hang, mid-stream error position, line-number execution order. 194 tests pass; goldens byte-identical.

Not included (noted in the doc): checkpoints for seek/scrub — straightforward on top of the line driver when the visualizer needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3

