### PR TITLE
Optional line_no column on batch/dataframe path, default off (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ Notable changes to **nc-gcode-interpreter**. The format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are git tags,
 released to PyPI.
 
-## [Unreleased]
+## [v0.2.1] - unreleased
+
+### Added
+
+- Optional `line_no` output column on the batch/dataframe path, gated by
+  `include_line_numbers=False` on `nc_to_dataframe` / `nc_to_batches`
+  (default off, so the output schema is unchanged unless requested). When
+  enabled it prepends a leading `Int64` column giving the 1-based source line
+  each output row came from - previously only the streaming `nc_to_rows`
+  exposed it. Loops repeat the value and jumps make it non-monotonic, matching
+  `nc_to_rows` row-for-row; flatten-generated samples keep the originating
+  block's line number; `dataframe_to_nc` ignores it (source provenance, not an
+  emittable word). Concatenating batches reconstructs the same per-row
+  `line_no` as the whole-file dataframe (#45)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ released to PyPI.
 
 ### Added
 
-- Optional `line_no` output column on the batch/dataframe path, gated by
-  `include_line_numbers=False` on `nc_to_dataframe` / `nc_to_batches`
-  (default off, so the output schema is unchanged unless requested). When
+- Optional `line_no` output column on the batch/dataframe path, enabled with
+  `include_line_numbers=True` on `nc_to_dataframe` / `nc_to_batches` (default
+  `False`, so the output schema is unchanged unless you ask for it). When
   enabled it prepends a leading `Int64` column giving the 1-based source line
   each output row came from - previously only the streaming `nc_to_rows`
   exposed it. Loops repeat the value and jumps make it non-monotonic, matching

--- a/python/nc_gcode_interpreter/__init__.py
+++ b/python/nc_gcode_interpreter/__init__.py
@@ -60,6 +60,7 @@ def nc_to_dataframe(
     axis_index_map: dict[str, int] | None = None,
     allow_undefined_variables: bool = False,
     flatten_tolerance: float | None = None,
+    include_line_numbers: bool = False,
 ) -> tuple[pl.DataFrame, dict]:
     """
     Parses Sinumerik-flavored NC G-code and converts it into a Polars DataFrame along with the final state.
@@ -93,6 +94,12 @@ def nc_to_dataframe(
         deviation (in path units, i.e. mm) of the true curve. The interpolation
         parameters (I/J/K/CR, PW/SD/PL) are consumed and do not appear in the
         output. Default None (curves pass through untouched).
+    include_line_numbers: bool, optional
+        If True, prepend a `line_no` (Int64) column giving the 1-based source
+        line each output row came from - repeated under a loop, non-monotonic
+        across a jump, matching the streaming `nc_to_rows`. Never
+        forward-filled; `dataframe_to_nc` ignores it. Default False (column
+        absent, output schema unchanged).
 
     Returns:
     --------
@@ -142,6 +149,7 @@ def nc_to_dataframe(
         allow_undefined_variables,
         input_is_path,
         flatten_tolerance,
+        include_line_numbers,
     )
     # pl.DataFrame wraps each Arrow record batch via __arrow_c_array__ (polars
     # >= 1.3), no pyarrow needed. Exhaust the iterator before reading .state.
@@ -245,6 +253,13 @@ def sanitize_dataframe(
     pl.DataFrame
         The sanitized DataFrame ready for analysis or conversion back to G-code.
     """
+    # `line_no` (present only when interpreted with include_line_numbers=True)
+    # is source-provenance metadata, not an emittable G-code word; drop it up
+    # front so it is never cast/forward-filled or written back out by
+    # dataframe_to_nc.
+    if "line_no" in df.columns:
+        df = df.drop("line_no")
+
     modal = [g["short_name"] for g in GGroups.g_groups if g["effectiveness"] == "modal"]
     non_modal = [g["short_name"] for g in GGroups.g_groups if g["effectiveness"] != "modal"]
     known_axes = [
@@ -493,6 +508,7 @@ def nc_to_batches(
     axis_index_map: dict[str, int] | None = None,
     allow_undefined_variables: bool = False,
     flatten_tolerance: float | None = None,
+    include_line_numbers: bool = False,
 ) -> _BatchIterator:
     """Interpret an NC program into a stream of columnar polars DataFrames.
 
@@ -518,6 +534,11 @@ def nc_to_batches(
     internally via ``ParsingError::StreamClosed``, unwinding the thread
     promptly instead of finishing the rest of the program.
 
+    With ``include_line_numbers=True`` every batch gains a leading ``line_no``
+    (Int64) column: the 1-based source line each row came from (repeated under
+    a loop, non-monotonic across a jump), never forward-filled. Default False
+    leaves the schema unchanged.
+
     Example:
     --------
     >>> batches = nc_to_batches("G1 X10\\nX20 Y5", batch_size=1)
@@ -540,5 +561,6 @@ def nc_to_batches(
         allow_undefined_variables,
         input_is_path,
         flatten_tolerance,
+        include_line_numbers,
     )
     return _BatchIterator(inner)

--- a/python/nc_gcode_interpreter/_internal.pyi
+++ b/python/nc_gcode_interpreter/_internal.pyi
@@ -33,6 +33,7 @@ def nc_to_batches(
     allow_undefined_variables: bool = False,
     input_is_path: bool = False,
     flatten_tolerance: Optional[float] = None,
+    include_line_numbers: bool = False,
 ) -> Any:
     """Interpret an NC program into an iterator of columnar polars DataFrames."""
     ...

--- a/python/tests/test_batches.py
+++ b/python/tests/test_batches.py
@@ -191,3 +191,20 @@ def test_include_line_numbers_matches_streaming_under_jumps():
     df, _ = nc_to_dataframe(prog, include_line_numbers=True)
     streamed = [line_no for line_no, _row in nc_to_rows(prog)]
     assert df["line_no"].to_list() == streamed == [1, 4]
+
+
+def test_include_line_numbers_survives_flattening():
+    """Flatten-generated samples keep the originating block's source line, so a
+    flattened arc/spline block yields many rows all carrying its line_no - and
+    still matches the streaming path row-for-row."""
+    from nc_gcode_interpreter import nc_to_rows
+
+    program = "G1 X0 Y0 F1000\nG2 X100 Y0 I50 J0\nG1 X100 Y50\n"
+    df, _ = nc_to_dataframe(program, flatten_tolerance=0.1, include_line_numbers=True)
+    assert df.columns[0] == "line_no"
+    assert df["line_no"].null_count() == 0
+    per_line = df["line_no"].to_list()
+    # The arc on line 2 expands to many G1 samples, every one tagged line 2.
+    assert per_line.count(2) > 5
+    stream_lines = [line for line, *_ in nc_to_rows(program, flatten_tolerance=0.1)]
+    assert per_line == stream_lines

--- a/python/tests/test_batches.py
+++ b/python/tests/test_batches.py
@@ -155,3 +155,39 @@ def test_path_input_batches(tmp_path):
     df, _ = nc_to_dataframe(program)
     frames = list(nc_to_batches(mpf, batch_size=2))
     assert_frame_equal(pl.concat(frames, how="diagonal").select(df.columns), df)
+
+
+def test_include_line_numbers_is_opt_in():
+    """`line_no` is off by default and, when enabled, is a leading Int64 column
+    that repeats under a loop and is non-monotonic across a jump - matching the
+    streaming `nc_to_rows` row-for-row and reconstructible across batches."""
+    prog = "R1=0\nWHILE R1<2\nX=R1 F100\nR1=R1+1\nENDWHILE\nX9\n"
+
+    # Default off: schema unchanged, no line_no column anywhere.
+    df_off, _ = nc_to_dataframe(prog)
+    assert "line_no" not in df_off.columns
+    off_batches = list(nc_to_batches(prog, batch_size=1))
+    assert all("line_no" not in f.columns for f in off_batches)
+
+    # Opt-in: leading Int64 line_no with the loop's repeated source lines.
+    df_on, _ = nc_to_dataframe(prog, include_line_numbers=True)
+    assert df_on.columns[0] == "line_no"
+    assert df_on["line_no"].dtype == pl.Int64
+    assert df_on["line_no"].to_list() == [3, 3, 6]
+    # Dropping line_no reproduces the default-off frame exactly.
+    assert_frame_equal(df_on.drop("line_no"), df_off)
+
+    # Batches carry it too and concatenate back to the whole-file column.
+    on_batches = list(nc_to_batches(prog, batch_size=1, include_line_numbers=True))
+    assert pl.concat(on_batches, how="diagonal")["line_no"].to_list() == [3, 3, 6]
+
+
+def test_include_line_numbers_matches_streaming_under_jumps():
+    """A GOTO reorders execution; the batch `line_no` column must match what
+    the streaming `nc_to_rows` yields, line for line."""
+    from nc_gcode_interpreter import nc_to_rows
+
+    prog = "N10 X1\nGOTOF 40\nN30 X999\nN40 X4\n"
+    df, _ = nc_to_dataframe(prog, include_line_numbers=True)
+    streamed = [line_no for line_no, _row in nc_to_rows(prog)]
+    assert df["line_no"].to_list() == streamed == [1, 4]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -149,6 +149,7 @@ pub fn nc_to_batch_stream(
     allow_undefined_variables: bool,
     flatten_tolerance: Option<f64>,
     batch_size: usize,
+    emit_line_no: bool,
     sender: std::sync::mpsc::SyncSender<Table>,
 ) -> Result<state::State, ParsingError> {
     let mut state = build_state(
@@ -162,7 +163,7 @@ pub fn nc_to_batch_stream(
         let mut discard = OutputRows::collect();
         interpret_file(initial_state, &mut state, &mut discard)?;
     }
-    let mut output = OutputRows::batch_stream(sender, batch_size, disable_forward_fill);
+    let mut output = OutputRows::batch_stream(sender, batch_size, disable_forward_fill, emit_line_no);
     install_flattener(&mut output, &state, flatten_tolerance)?;
     interpret_file(input, &mut state, &mut output)?;
     output.finish()?;
@@ -515,6 +516,56 @@ mod tests {
         let (table, _state) = nc_to_table(input, None, None, None, 10000, false, None, false, None)
             .expect("program should interpret");
         table
+    }
+
+    /// Interpret through the batch path with `include_line_numbers` on. A
+    /// large batch size keeps small programs to a single batch, so the one
+    /// emitted [`Table`] carries the whole program's `line_no` column.
+    fn interpret_with_line_numbers(input: &str) -> Table {
+        let (tx, rx) = std::sync::mpsc::sync_channel(64);
+        nc_to_batch_stream(
+            input, None, None, None, 10000, false, None, false, None, 1_000_000, true, tx,
+        )
+        .expect("program should interpret");
+        rx.into_iter().next().expect("one batch for a small program")
+    }
+
+    fn ints<'a>(table: &'a Table, name: &str) -> &'a [Option<i64>] {
+        table
+            .columns
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, c)| match c {
+                Column::Int(v) => v.as_slice(),
+                other => panic!("column {name} is not an int column: {other:?}"),
+            })
+            .unwrap_or_else(|| panic!("column {name} missing; have {:?}", column_names(table)))
+    }
+
+    /// `include_line_numbers` (default off) prepends a `line_no` column: one
+    /// 1-based source line per output row, repeated under a loop and
+    /// non-monotonic across a jump - matching what `nc_to_rows` yields.
+    #[test]
+    fn line_no_column_is_opt_in_and_tracks_source_lines() {
+        // Default off: the ordinary path never emits a line_no column.
+        let table = interpret("G1 X0 Y0 F100\nX10\n");
+        assert!(!column_names(&table).contains(&"line_no"));
+
+        // Opt-in: line_no leads the columns and is 1-based.
+        let table = interpret_with_line_numbers("G1 X0 Y0 F100\nX10\nX20\n");
+        assert_eq!(column_names(&table).first(), Some(&"line_no"));
+        assert_eq!(ints(&table, "line_no"), &[Some(1), Some(2), Some(3)]);
+
+        // WHILE loop: the body (line 3) repeats; line 4 assigns a plain
+        // variable and emits no output row; line 6 follows the loop.
+        let table =
+            interpret_with_line_numbers("R1=0\nWHILE R1<2\nX=R1\nR1=R1+1\nENDWHILE\nX9\n");
+        assert_eq!(ints(&table, "line_no"), &[Some(3), Some(3), Some(6)]);
+
+        // GOTO reorders execution: only the source lines that ran appear, in
+        // execution order (line 1, then the jump target line 4).
+        let table = interpret_with_line_numbers("N10 X1\nGOTOF 40\nN30 X999\nN40 X4\n");
+        assert_eq!(ints(&table, "line_no"), &[Some(1), Some(4)]);
     }
 
     fn floats<'a>(table: &'a Table, name: &str) -> &'a [Option<f64>] {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -138,7 +138,42 @@ pub fn nc_to_row_stream(
 /// `nc_to_batches` iterator.
 #[allow(clippy::too_many_arguments)]
 #[allow(dead_code)] // used by the python-feature bindings, not the bin
+#[allow(clippy::too_many_arguments)]
 pub fn nc_to_batch_stream(
+    input: &str,
+    initial_state: Option<&str>,
+    axis_identifiers: Option<Vec<String>>,
+    extra_axes: Option<Vec<String>>,
+    iteration_limit: usize,
+    disable_forward_fill: bool,
+    axis_index_map: Option<HashMap<String, usize>>,
+    allow_undefined_variables: bool,
+    flatten_tolerance: Option<f64>,
+    batch_size: usize,
+    sender: std::sync::mpsc::SyncSender<Table>,
+) -> Result<state::State, ParsingError> {
+    // Back-compatible entry point: never emits the opt-in line_no column.
+    nc_to_batch_stream_with_line_numbers(
+        input,
+        initial_state,
+        axis_identifiers,
+        extra_axes,
+        iteration_limit,
+        disable_forward_fill,
+        axis_index_map,
+        allow_undefined_variables,
+        flatten_tolerance,
+        batch_size,
+        false,
+        sender,
+    )
+}
+
+/// As [`nc_to_batch_stream`], but with the opt-in `line_no` column. Separate
+/// function so `nc_to_batch_stream`'s signature stays stable for existing Rust
+/// callers.
+#[allow(clippy::too_many_arguments)]
+pub fn nc_to_batch_stream_with_line_numbers(
     input: &str,
     initial_state: Option<&str>,
     axis_identifiers: Option<Vec<String>>,
@@ -163,7 +198,8 @@ pub fn nc_to_batch_stream(
         let mut discard = OutputRows::collect();
         interpret_file(initial_state, &mut state, &mut discard)?;
     }
-    let mut output = OutputRows::batch_stream(sender, batch_size, disable_forward_fill, emit_line_no);
+    let mut output =
+        OutputRows::batch_stream_with_line_numbers(sender, batch_size, disable_forward_fill, emit_line_no);
     install_flattener(&mut output, &state, flatten_tolerance)?;
     interpret_file(input, &mut state, &mut output)?;
     output.finish()?;
@@ -523,7 +559,7 @@ mod tests {
     /// emitted [`Table`] carries the whole program's `line_no` column.
     fn interpret_with_line_numbers(input: &str) -> Table {
         let (tx, rx) = std::sync::mpsc::sync_channel(64);
-        nc_to_batch_stream(
+        nc_to_batch_stream_with_line_numbers(
             input, None, None, None, 10000, false, None, false, None, 1_000_000, true, tx,
         )
         .expect("program should interpret");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ mod python_bindings {
         axis_index_map: Option<HashMap<String, usize>>,
         allow_undefined_variables: bool,
         flatten_tolerance: Option<f64>,
+        emit_line_no: bool,
     ) -> PyResult<(
         mpsc::Receiver<Table>,
         mpsc::Receiver<Result<FinalState, String>>,
@@ -225,6 +226,7 @@ mod python_bindings {
                     allow_undefined_variables,
                     flatten_tolerance,
                     batch_size,
+                    emit_line_no,
                     batch_sender,
                 );
                 let message = match outcome {
@@ -553,7 +555,7 @@ mod python_bindings {
     /// thread. Wrapping each with `pl.DataFrame` and concatenating reconstructs
     /// `nc_to_dataframe`.
     #[pyfunction]
-    #[pyo3(signature = (input, batch_size = 500_000, initial_state = None, axis_identifiers = None, extra_axes = None, iteration_limit = 10000, disable_forward_fill = false, axis_index_map = None, allow_undefined_variables = false, input_is_path = false, flatten_tolerance = None))]
+    #[pyo3(signature = (input, batch_size = 500_000, initial_state = None, axis_identifiers = None, extra_axes = None, iteration_limit = 10000, disable_forward_fill = false, axis_index_map = None, allow_undefined_variables = false, input_is_path = false, flatten_tolerance = None, include_line_numbers = false))]
     #[allow(clippy::too_many_arguments)]
     fn nc_to_batches(
         input: String,
@@ -567,6 +569,7 @@ mod python_bindings {
         allow_undefined_variables: bool,
         input_is_path: bool,
         flatten_tolerance: Option<f64>,
+        include_line_numbers: bool,
     ) -> PyResult<NcBatchIterator> {
         if batch_size == 0 {
             return Err(PyErr::new::<PyValueError, _>("batch_size must be greater than 0"));
@@ -590,6 +593,7 @@ mod python_bindings {
             axis_index_map,
             allow_undefined_variables,
             flatten_tolerance,
+            include_line_numbers,
         )?;
 
         Ok(NcBatchIterator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ mod python_bindings {
     }
     use std::sync::{mpsc, Mutex};
 
-    use crate::interpreter::{nc_to_batch_stream, nc_to_row_stream};
+    use crate::interpreter::{nc_to_batch_stream_with_line_numbers, nc_to_row_stream};
     use crate::output::{is_forward_filled_column, is_string_column, Column, Row, Table};
     use crate::types::Value;
 
@@ -215,7 +215,7 @@ mod python_bindings {
         let handle = std::thread::Builder::new()
             .name("nc-interpreter".to_string())
             .spawn(move || {
-                let outcome = nc_to_batch_stream(
+                let outcome = nc_to_batch_stream_with_line_numbers(
                     &input,
                     initial_state.as_deref(),
                     axis_identifiers,

--- a/src/output.rs
+++ b/src/output.rs
@@ -236,12 +236,13 @@ impl OutputRows {
         sender: std::sync::mpsc::SyncSender<Table>,
         batch_size: usize,
         disable_forward_fill: bool,
+        emit_line_no: bool,
     ) -> Self {
         OutputRows {
             current: Row::default(),
             sink: RowSink::Batch(BatchStreamSink {
                 sender,
-                builder: BatchBuilder::new(disable_forward_fill),
+                builder: BatchBuilder::new(disable_forward_fill, emit_line_no),
                 buffer: Vec::new(),
                 batch_size,
             }),
@@ -516,6 +517,14 @@ fn rekey_g4_dwell(row: &mut Row) {
 /// block addresses: never forward-filled.
 pub const FLATTENED_COLUMN: &str = "flattened";
 
+/// Leading column carrying each output row's 1-based source line number (the
+/// `Row::line_no` the streaming path yields). One value per row, never
+/// forward-filled and never null; loops and jumps produce repeated /
+/// non-monotonic values, exactly matching `nc_to_rows`. Not a cell key, so it
+/// sits outside `canonical_order` and is prepended to every batch. Opt-in via
+/// the batch/dataframe `include_line_numbers` flag (default off).
+pub const LINE_NO_COLUMN: &str = "line_no";
+
 /// Canonical output-column order over the set of columns present so far:
 /// N, modal then non-modal G-group columns, the fixed axis columns, any
 /// remaining value columns (e.g. user extra axes) in alphabetical order, the
@@ -572,6 +581,8 @@ fn canonical_order(present: &HashSet<&'static str>) -> Vec<&'static str> {
 /// `from_rows` is now implemented.
 pub struct BatchBuilder {
     disable_forward_fill: bool,
+    /// Prepend the `line_no` source-line column to every batch (opt-in).
+    emit_line_no: bool,
     /// Columns seen in any batch so far, in canonical order. Grows monotonically
     /// so a column, once emitted, stays in every later batch (forward-filled or
     /// null), which is what lets the batches concatenate back to the whole
@@ -582,9 +593,10 @@ pub struct BatchBuilder {
 }
 
 impl BatchBuilder {
-    pub fn new(disable_forward_fill: bool) -> Self {
+    pub fn new(disable_forward_fill: bool, emit_line_no: bool) -> Self {
         BatchBuilder {
             disable_forward_fill,
+            emit_line_no,
             columns: Vec::new(),
             fill: HashMap::new(),
         }
@@ -601,9 +613,10 @@ impl BatchBuilder {
     pub fn build_batch(&mut self, rows: &[Row]) -> Table {
         // Skip rows that carry no output values (blocks that only affected
         // internal state, e.g. definitions - their variable_changes are a
-        // streaming-only concern).
-        let cells: Vec<&CellMap> =
-            rows.iter().map(|r| &r.cells).filter(|r| !r.is_empty()).collect();
+        // streaming-only concern). Keep the whole `Row` so the source line
+        // number is available alongside the cells when `emit_line_no` is set.
+        let kept: Vec<&Row> = rows.iter().filter(|r| !r.cells.is_empty()).collect();
+        let cells: Vec<&CellMap> = kept.iter().map(|r| &r.cells).collect();
 
         // Union of every column seen so far with those present in this batch.
         let mut present: HashSet<&'static str> = self.columns.iter().copied().collect();
@@ -632,7 +645,16 @@ impl BatchBuilder {
             }
         }
 
-        let mut columns: Vec<(String, Column)> = Vec::with_capacity(self.columns.len());
+        // Opt-in (default off): the source line number leads every batch, one
+        // value per kept row, never null and never forward-filled. It is not a
+        // cell key, so it stays out of `self.columns` / `canonical_order` and is
+        // simply prepended. Default off keeps the output schema unchanged.
+        let extra = usize::from(self.emit_line_no);
+        let mut columns: Vec<(String, Column)> = Vec::with_capacity(self.columns.len() + extra);
+        if self.emit_line_no {
+            let line_no_column = Column::Int(kept.iter().map(|r| Some(r.line_no as i64)).collect());
+            columns.push((LINE_NO_COLUMN.to_string(), line_no_column));
+        }
         for (&name, builder) in self.columns.iter().zip(builders) {
             let mut column = builder.into_column();
             // Block addresses (spline PW/SD/PL) are never forward-filled: a
@@ -727,7 +749,8 @@ impl Table {
     /// forward-filled unless disabled. Equivalent to a single [`BatchBuilder`]
     /// batch over all rows.
     pub fn from_rows(rows: &[Row], disable_forward_fill: bool) -> Table {
-        BatchBuilder::new(disable_forward_fill).build_batch(rows)
+        // The whole-file / CLI path never emits line_no (opt-in, default off).
+        BatchBuilder::new(disable_forward_fill, false).build_batch(rows)
     }
 
     pub fn height(&self) -> usize {

--- a/src/output.rs
+++ b/src/output.rs
@@ -236,13 +236,24 @@ impl OutputRows {
         sender: std::sync::mpsc::SyncSender<Table>,
         batch_size: usize,
         disable_forward_fill: bool,
+    ) -> Self {
+        // Back-compatible entry point: never emits line_no.
+        Self::batch_stream_with_line_numbers(sender, batch_size, disable_forward_fill, false)
+    }
+
+    /// As [`batch_stream`](Self::batch_stream), but with the opt-in `line_no`
+    /// column. Separate constructor so `batch_stream`'s signature stays stable.
+    pub fn batch_stream_with_line_numbers(
+        sender: std::sync::mpsc::SyncSender<Table>,
+        batch_size: usize,
+        disable_forward_fill: bool,
         emit_line_no: bool,
     ) -> Self {
         OutputRows {
             current: Row::default(),
             sink: RowSink::Batch(BatchStreamSink {
                 sender,
-                builder: BatchBuilder::new(disable_forward_fill, emit_line_no),
+                builder: BatchBuilder::new(disable_forward_fill).with_line_numbers(emit_line_no),
                 buffer: Vec::new(),
                 batch_size,
             }),
@@ -593,13 +604,21 @@ pub struct BatchBuilder {
 }
 
 impl BatchBuilder {
-    pub fn new(disable_forward_fill: bool, emit_line_no: bool) -> Self {
+    pub fn new(disable_forward_fill: bool) -> Self {
         BatchBuilder {
             disable_forward_fill,
-            emit_line_no,
+            emit_line_no: false,
             columns: Vec::new(),
             fill: HashMap::new(),
         }
+    }
+
+    /// Opt into the leading `line_no` column (default off). Builder-style so
+    /// `BatchBuilder::new(..)` stays a stable single-argument constructor for
+    /// existing Rust callers.
+    pub fn with_line_numbers(mut self, emit_line_no: bool) -> Self {
+        self.emit_line_no = emit_line_no;
+        self
     }
 
     /// Build the [`Table`] for one batch of rows, updating the carried
@@ -750,7 +769,7 @@ impl Table {
     /// batch over all rows.
     pub fn from_rows(rows: &[Row], disable_forward_fill: bool) -> Table {
         // The whole-file / CLI path never emits line_no (opt-in, default off).
-        BatchBuilder::new(disable_forward_fill, false).build_batch(rows)
+        BatchBuilder::new(disable_forward_fill).build_batch(rows)
     }
 
     pub fn height(&self) -> usize {


### PR DESCRIPTION
Supersedes #51. Same tested `line_no` semantics, but **opt-in** (`include_line_numbers=False`) instead of default-on — so it is non-breaking and fits a 0.2.1 release.

## What
- `nc_to_dataframe(..., include_line_numbers=True)` and `nc_to_batches(..., include_line_numbers=True)` prepend a leading `line_no` (Int64) column: the 1-based source line each output row came from. Never null, never forward-filled, outside `canonical_order`.
- Loops repeat it, jumps make it non-monotonic — matches streaming `nc_to_rows` row-for-row.
- Default off → output schema, every `examples/*.csv`, and the CLI path are unchanged (no CSV regen in this PR).
- `dataframe_to_nc` ignores it (`sanitize_dataframe` drops it).

## How
The flag is threaded only through the Python batch stream (`nc_to_batches` → `spawn_batch_stream` → `nc_to_batch_stream` → `OutputRows::batch_stream` → `BatchBuilder`), gated on `BatchBuilder.emit_line_no`. `from_rows`/`nc_to_table` keep their signatures, so no churn at their ~20 call sites and no conflict with #50's arity test.

## vs #51
#51 made the column default-on and regenerated all example CSVs (a breaking schema change for every consumer). Per maintainer direction, this makes it opt-in instead. #51 can be closed in favor of this.

## Tests
- Rust: `line_no_column_is_opt_in_and_tracks_source_lines` (default-off, plus opt-in under WHILE loop + GOTO via the batch stream).
- Python: opt-in leading column/dtype, default-off frame parity (`df_on.drop("line_no") == df_off`), cross-batch reconstruction, streaming parity under a jump.
- `cargo test` 50 lib + 2 cli green; `pytest` 309 passed / 1 skipped; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3

Closes #45.