### PR TITLE
Variable-change events on the batch path + string_table in state dict (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Notable changes to **nc-gcode-interpreter**. The format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are git tags,
 released to PyPI.
 
+## [Unreleased]
+
+### Added
+
+- Variable-change events on the batch path: `nc_to_batches(...,
+  include_variables=True)` exposes, once exhausted, a sparse `variable_events`
+  DataFrame (`row_idx` / `name_id` / `value`) plus a `variable_names` list -
+  the batch-path twin of the per-row `variables` dict `nc_to_rows` already
+  yields. `row_idx` is the output-row index a change is seen at (a change on a
+  variable-only block is attributed to the next output row), so replaying the
+  events reconstructs the symbol table at any row. Off by default (no cost).
+- `string_table` in the interpreter state dict: `DEF STRING` variables now
+  round-trip into `.state` / the `nc_to_dataframe` state tuple as
+  `state["string_table"]` (`dict[str, str]`), alongside the existing `axes` /
+  `symbol_table` / `translation` numeric tables (previously omitted).
+
 ## [v0.2.1] - 2026-07-07
 
 ### Added

--- a/python/nc_gcode_interpreter/__init__.py
+++ b/python/nc_gcode_interpreter/__init__.py
@@ -498,6 +498,29 @@ class _BatchIterator:
     def state(self) -> dict | None:
         return self._inner.state
 
+    @property
+    def variable_events(self) -> "pl.DataFrame | None":
+        """Sparse variable-change events (``include_variables=True``).
+
+        A :class:`polars.DataFrame` with columns ``row_idx`` (the output-row
+        index the change is seen at), ``name_id`` (index into
+        :attr:`variable_names`) and ``value``. ``None`` unless the iterator was
+        created with ``include_variables=True``. Available once exhausted.
+        Replaying the events in order (decoding ``name_id`` via
+        :attr:`variable_names`) reconstructs the symbol table at any row, the
+        batch-path twin of the per-row ``variables`` dict ``nc_to_rows`` yields.
+        """
+        batch = self._inner.variable_events
+        return None if batch is None else pl.DataFrame(batch)
+
+    @property
+    def variable_names(self) -> list[str] | None:
+        """Variable names ``variable_events.name_id`` indexes into.
+
+        ``None`` unless ``include_variables=True``; available once exhausted.
+        """
+        return self._inner.variable_names
+
 
 def nc_to_batches(
     input: "TextFileLike | str | os.PathLike",
@@ -511,6 +534,7 @@ def nc_to_batches(
     allow_undefined_variables: bool = False,
     flatten_tolerance: float | None = None,
     include_line_numbers: bool = False,
+    include_variables: bool = False,
 ) -> _BatchIterator:
     """Interpret an NC program into a stream of columnar polars DataFrames.
 
@@ -541,6 +565,12 @@ def nc_to_batches(
     a loop, non-monotonic across a jump), never forward-filled. Default False
     leaves the schema unchanged.
 
+    With ``include_variables=True`` the iterator additionally exposes
+    ``variable_events`` (a sparse :class:`polars.DataFrame` of ``row_idx`` /
+    ``name_id`` / ``value``) and ``variable_names`` once exhausted — the
+    batch-path equivalent of the per-row ``variables`` dict :func:`nc_to_rows`
+    yields; replaying the events reconstructs the symbol table at any row.
+
     Example:
     --------
     >>> batches = nc_to_batches("G1 X10\\nX20 Y5", batch_size=1)
@@ -564,5 +594,6 @@ def nc_to_batches(
         input_is_path,
         flatten_tolerance,
         include_line_numbers,
+        include_variables,
     )
     return _BatchIterator(inner)

--- a/python/nc_gcode_interpreter/_internal.pyi
+++ b/python/nc_gcode_interpreter/_internal.pyi
@@ -43,8 +43,15 @@ def nc_to_batches(
     input_is_path: bool = False,
     flatten_tolerance: Optional[float] = None,
     include_line_numbers: bool = False,
+    include_variables: bool = False,
 ) -> Any:
-    """Interpret an NC program into an iterator of columnar polars DataFrames."""
+    """Interpret an NC program into an iterator of columnar polars DataFrames.
+
+    The returned iterator exposes ``state`` (dict with ``axes``,
+    ``symbol_table``, ``translation`` and ``string_table``) once exhausted, and
+    - when ``include_variables`` is set - ``variable_events`` (an Arrow batch of
+    ``row_idx`` / ``name_id`` / ``value``) and ``variable_names`` (list[str]).
+    """
     ...
 
 __all__ = ["nc_to_rows", "nc_to_batches"]

--- a/python/tests/test_batch_variables.py
+++ b/python/tests/test_batch_variables.py
@@ -1,0 +1,205 @@
+"""Batch-path variable-change events (#46) + `string_table` in the state dict.
+
+The streaming `nc_to_rows(include_variables=True)` path yields a per-row
+`variables` dict; the batch path (`nc_to_batches` / `nc_to_dataframe`) now
+surfaces the same information as a sparse side-table (`row_idx`, `name_id`,
+`value`) plus a `variable_names` list. These tests pin (a) parity of the
+ordered assignment sequence between the two paths and (b) that `DEF STRING`
+variables round-trip into the returned state dict.
+"""
+
+import polars as pl
+
+from nc_gcode_interpreter import nc_to_batches, nc_to_dataframe, nc_to_rows
+
+
+def _stream_sequence(program: str) -> list[tuple[str, float]]:
+    """Flat, ordered `(name, value)` assignment sequence from the stream."""
+    return [
+        (name, value)
+        for _line, _row, variables in nc_to_rows(program, include_variables=True)
+        for name, value in variables.items()
+    ]
+
+
+def _batch_sequence(it) -> list[tuple[str, float]]:
+    """Flat, ordered `(name, value)` sequence decoded from the batch events."""
+    events = it.variable_events
+    names = it.variable_names
+    return [
+        (names[name_id], value)
+        for name_id, value in zip(events["name_id"], events["value"])
+    ]
+
+
+def test_batch_variable_events_match_stream_simple():
+    program = "\n".join(
+        [
+            "DEF REAL Q=2.5",  # variable-only
+            "R1=0",            # variable-only
+            "X=R1",            # output row, no change
+            "X=Q",             # output row, no change
+        ]
+    )
+    it = nc_to_batches(program, include_variables=True)
+    list(it)  # exhaust to populate variable_events / state
+    assert _batch_sequence(it) == _stream_sequence(program)
+
+
+def test_batch_variable_events_match_stream_while_loop():
+    # A WHILE loop where R1 changes once per iteration: the per-iteration
+    # counter events must appear on the batch path exactly as they do on the
+    # stream, in the same order.
+    program = "\n".join(
+        [
+            "DEF REAL Q=2.5",
+            "R1=0",
+            "WHILE R1<3",
+            "X=R1 Q=Q*2",  # output row that ALSO assigns a variable
+            "R1=R1+1",     # variable-only, per iteration
+            "ENDWHILE",
+            "X=Q",
+        ]
+    )
+    it = nc_to_batches(program, include_variables=True)
+    list(it)
+    assert _batch_sequence(it) == _stream_sequence(program)
+
+
+def test_batch_variable_events_row_idx_reconstructs_symbol_table():
+    # Replaying every event reconstructs the final symbol table (minus the
+    # built-in TRUE/FALSE), mirroring the streaming accumulation invariant.
+    program = "\n".join(
+        [
+            "DEF REAL Q=1",
+            "R1=0",
+            "WHILE R1<3",
+            "X=R1 Q=Q*2",
+            "R1=R1+1",
+            "ENDWHILE",
+        ]
+    )
+    it = nc_to_batches(program, include_variables=True)
+    list(it)
+    accumulated: dict[str, float] = {}
+    for name, value in _batch_sequence(it):
+        accumulated[name] = value
+    symbol_table = dict(it.state["symbol_table"])
+    for builtin in ("TRUE", "FALSE"):
+        symbol_table.pop(builtin)
+    assert accumulated == symbol_table
+
+    # row_idx is monotonic non-decreasing (events arrive in program order) and
+    # bounded by the number of output rows.
+    events = it.variable_events
+    row_idx = events["row_idx"].to_list()
+    assert row_idx == sorted(row_idx)
+
+
+def test_batch_variable_events_row_idx_aligns_with_output_rows():
+    # A change on a variable-only block is attributed to the NEXT output row;
+    # a change on an output row gets that row's own index.
+    program = "\n".join(
+        [
+            "R1=0",   # variable-only, before output row 0
+            "X=R1",   # output row 0
+            "R1=1",   # variable-only, before output row 1
+            "X=R1",   # output row 1
+        ]
+    )
+    it = nc_to_batches(program, include_variables=True)
+    list(it)
+    events = it.variable_events
+    names = it.variable_names
+    decoded = [
+        (row_idx, names[name_id], value)
+        for row_idx, name_id, value in zip(
+            events["row_idx"], events["name_id"], events["value"]
+        )
+    ]
+    assert decoded == [(0, "R1", 0.0), (1, "R1", 1.0)]
+
+
+def test_batch_variable_events_absent_without_flag():
+    it = nc_to_batches("R1=5\nX=R1")
+    list(it)
+    assert it.variable_events is None
+    assert it.variable_names is None
+
+
+def test_batch_variable_events_empty_when_no_assignments():
+    it = nc_to_batches("G1 X10\nX20 Y5", include_variables=True)
+    list(it)
+    assert isinstance(it.variable_events, pl.DataFrame)
+    assert it.variable_events.height == 0
+    assert it.variable_names == []
+
+
+def test_string_table_round_trips_through_state_dict():
+    program = "\n".join(
+        [
+            "DEF STRING[16] MSG",
+            'MSG="HELLO WORLD"',
+            "DEF STRING[8] TAG",
+            'TAG="ABC"',
+            "G1 X1",
+        ]
+    )
+    _df, state = nc_to_dataframe(program)
+    assert state["string_table"] == {"MSG": "HELLO WORLD", "TAG": "ABC"}
+    # The existing numeric sub-tables are untouched by the new key.
+    assert set(state) == {"axes", "symbol_table", "translation", "string_table"}
+    # The string variable never leaks into the numeric symbol table.
+    assert "MSG" not in state["symbol_table"]
+
+
+def test_string_table_on_streaming_and_batch_iterators():
+    program = 'DEF STRING[8] MSG\nMSG="HI"\nG1 X1'
+    rows = nc_to_rows(program)
+    list(rows)
+    assert rows.state["string_table"] == {"MSG": "HI"}
+
+    it = nc_to_batches(program)
+    list(it)
+    assert it.state["string_table"] == {"MSG": "HI"}
+
+
+def test_line_numbers_and_variables_compose_on_the_batch_path():
+    # include_line_numbers (#45) and include_variables (#46) share the batch
+    # path and were merged independently; requesting both at once must give the
+    # leading `line_no` column AND the sparse variable-event side-table, with
+    # `row_idx` still aligned to the emitted (line_no-carrying) output rows.
+    program = "\n".join(
+        [
+            "R1=0",          # variable-only, before output row 0
+            "WHILE R1<3",
+            "X=R1",          # output row (loop body, source line 3)
+            "R1=R1+1",       # variable-only
+            "ENDWHILE",
+            "X9",            # output row, source line 6
+        ]
+    )
+    it = nc_to_batches(
+        program,
+        batch_size=1_000_000,
+        include_line_numbers=True,
+        include_variables=True,
+    )
+    df = pl.concat(list(it), how="diagonal")
+
+    # line_no leads and tracks source lines (loop body repeats line 3).
+    assert df.columns[0] == "line_no"
+    assert df["line_no"].to_list() == [3, 3, 3, 6]
+    assert df["X"].to_list() == [0.0, 1.0, 2.0, 9.0]
+
+    # Variable events still decode independently of the line_no column.
+    names = it.variable_names
+    decoded = [
+        (row_idx, names[name_id], value)
+        for row_idx, name_id, value in zip(
+            it.variable_events["row_idx"],
+            it.variable_events["name_id"],
+            it.variable_events["value"],
+        )
+    ]
+    assert decoded == [(0, "R1", 0.0), (1, "R1", 1.0), (2, "R1", 2.0), (3, "R1", 3.0)]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -156,6 +156,8 @@ pub fn nc_to_batch_stream(
     flatten_tolerance: Option<f64>,
     batch_size: usize,
     sender: std::sync::mpsc::SyncSender<Table>,
+    include_variables: bool,
+    events_sender: std::sync::mpsc::Sender<crate::output::VariableEvents>,
 ) -> Result<state::State, ParsingError> {
     // Back-compatible entry point: never emits the opt-in line_no column.
     nc_to_batch_stream_with_line_numbers(
@@ -171,6 +173,8 @@ pub fn nc_to_batch_stream(
         batch_size,
         false,
         sender,
+        include_variables,
+        events_sender,
     )
 }
 
@@ -191,6 +195,8 @@ pub fn nc_to_batch_stream_with_line_numbers(
     batch_size: usize,
     emit_line_no: bool,
     sender: std::sync::mpsc::SyncSender<Table>,
+    include_variables: bool,
+    events_sender: std::sync::mpsc::Sender<crate::output::VariableEvents>,
 ) -> Result<state::State, ParsingError> {
     let mut state = build_state(
         axis_identifiers,
@@ -203,7 +209,14 @@ pub fn nc_to_batch_stream_with_line_numbers(
         let mut discard = OutputRows::collect();
         interpret_file(initial_state, &mut state, &mut discard)?;
     }
-    let mut output = OutputRows::batch_stream_with_line_numbers(sender, batch_size, disable_forward_fill, emit_line_no);
+    let mut output = OutputRows::batch_stream_with_line_numbers(
+        sender,
+        batch_size,
+        disable_forward_fill,
+        include_variables,
+        events_sender,
+        emit_line_no,
+    );
     install_flattener(&mut output, &state, flatten_tolerance)?;
     interpret_file(input, &mut state, &mut output)?;
     output.finish()?;
@@ -584,8 +597,9 @@ mod tests {
     /// emitted [`Table`] carries the whole program's `line_no` column.
     fn interpret_with_line_numbers(input: &str) -> Table {
         let (tx, rx) = std::sync::mpsc::sync_channel(64);
+        let (events_tx, _events_rx) = std::sync::mpsc::channel();
         nc_to_batch_stream_with_line_numbers(
-            input, None, None, None, 10000, false, None, false, None, 1_000_000, true, tx,
+            input, None, None, None, 10000, false, None, false, None, 1_000_000, true, tx, false, events_tx,
         )
         .expect("program should interpret");
         rx.into_iter().next().expect("one batch for a small program")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,8 @@ mod python_bindings {
 
     use crate::errors::ErrorLocation;
     use crate::interpreter::{nc_to_batch_stream_with_line_numbers, nc_to_row_stream};
-    use crate::output::{is_forward_filled_column, is_string_column, Column, Row, Table};
+    use crate::output::{is_forward_filled_column, is_string_column, Column, Row, Table, VariableEvents};
+    use crate::state::FinalState;
     use crate::types::Value;
 
     pyo3::create_exception!(
@@ -106,6 +107,19 @@ mod python_bindings {
             let _ = value.setattr("line_text", line_text);
             err
         }
+    }
+
+    /// Render a [`FinalState`] as the Python `.state` dict:
+    /// `{axes, symbol_table, translation, string_table}`. The three numeric
+    /// sub-tables become `dict[str, float]`; `string_table` (DEF STRING
+    /// variables) becomes `dict[str, str]`. Shared by both iterators.
+    fn final_state_to_py<'py>(py: Python<'py>, state: &FinalState) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("axes", state.axes.clone())?;
+        dict.set_item("symbol_table", state.symbol_table.clone())?;
+        dict.set_item("translation", state.translation.clone())?;
+        dict.set_item("string_table", state.string_table.clone())?;
+        Ok(dict)
     }
 
     /// Build one Arrow [`RecordBatch`](arrow::record_batch::RecordBatch) directly
@@ -214,7 +228,7 @@ mod python_bindings {
                     row_sender,
                 );
                 let message = match outcome {
-                    Ok(state) => Ok(state.to_python_dict()),
+                    Ok(state) => Ok(state.final_state()),
                     // The consumer hung up: nothing to report to nobody.
                     Err(crate::errors::ParsingError::StreamClosed) => return,
                     Err(error) => Err(ErrInfo::from_error(&error)),
@@ -242,9 +256,11 @@ mod python_bindings {
         allow_undefined_variables: bool,
         flatten_tolerance: Option<f64>,
         emit_line_no: bool,
+        include_variables: bool,
     ) -> PyResult<(
         mpsc::Receiver<Table>,
         mpsc::Receiver<Result<FinalState, ErrInfo>>,
+        mpsc::Receiver<VariableEvents>,
         std::thread::JoinHandle<()>,
     )> {
         // A cap of 3 lets the worker build one batch ahead while the consumer
@@ -252,6 +268,10 @@ mod python_bindings {
         // buffering.
         let (batch_sender, batch_receiver) = mpsc::sync_channel::<Table>(3);
         let (result_sender, result_receiver) = mpsc::sync_channel::<Result<FinalState, ErrInfo>>(1);
+        // Variable-change events are a small sparse side-table sent once at the
+        // end; an unbounded channel so the worker never blocks emitting them
+        // (they are only read after the batch stream is drained).
+        let (events_sender, events_receiver) = mpsc::channel::<VariableEvents>();
 
         let handle = std::thread::Builder::new()
             .name("nc-interpreter".to_string())
@@ -269,9 +289,11 @@ mod python_bindings {
                     batch_size,
                     emit_line_no,
                     batch_sender,
+                    include_variables,
+                    events_sender,
                 );
                 let message = match outcome {
-                    Ok(state) => Ok(state.to_python_dict()),
+                    Ok(state) => Ok(state.final_state()),
                     // The consumer hung up: nothing to report to nobody.
                     Err(crate::errors::ParsingError::StreamClosed) => return,
                     Err(error) => Err(ErrInfo::from_error(&error)),
@@ -279,10 +301,8 @@ mod python_bindings {
                 let _ = result_sender.send(message);
             })
             .map_err(|e| PyErr::new::<PyValueError, _>(format!("failed to spawn interpreter thread: {}", e)))?;
-        Ok((batch_receiver, result_receiver, handle))
+        Ok((batch_receiver, result_receiver, events_receiver, handle))
     }
-
-    type FinalState = HashMap<String, HashMap<String, f64>>;
 
     /// Iterator over interpreted rows: `next()` yields
     /// `(line_no, {column: value})` while the interpreter runs on a worker
@@ -440,11 +460,12 @@ mod python_bindings {
             }
         }
 
-        /// The final interpreter state (axes, symbol_table, translation),
-        /// available once the iterator is exhausted.
+        /// The final interpreter state
+        /// (`{axes, symbol_table, translation, string_table}`), available once
+        /// the iterator is exhausted.
         #[getter]
-        fn state(&self) -> Option<FinalState> {
-            self.state.clone()
+        fn state<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
+            self.state.as_ref().map(|s| final_state_to_py(py, s)).transpose()
         }
     }
 
@@ -512,8 +533,14 @@ mod python_bindings {
     struct NcBatchIterator {
         batches: Option<Mutex<mpsc::Receiver<Table>>>,
         result: Option<Mutex<mpsc::Receiver<Result<FinalState, ErrInfo>>>>,
+        /// Set at construction only when `include_variables`; drained at finish
+        /// into `variable_events`.
+        events: Option<Mutex<mpsc::Receiver<VariableEvents>>>,
         handle: Option<std::thread::JoinHandle<()>>,
         state: Option<FinalState>,
+        /// The sparse variable-change side-table, available once exhausted.
+        /// `None` unless `include_variables` was set.
+        variable_events: Option<VariableEvents>,
     }
 
     impl NcBatchIterator {
@@ -527,6 +554,16 @@ mod python_bindings {
                         return Err(info.into_pyerr(py));
                     }
                     Err(_) => {}
+                }
+            }
+            // The worker sends the events (once) before dropping the batch
+            // sender, so by the time the batch stream has closed they are
+            // already queued on the unbounded channel; a hung-up / disabled run
+            // yields `Err` and leaves `variable_events` as `None`.
+            if let Some(events) = self.events.take() {
+                let receiver = events.into_inner().expect("events receiver mutex poisoned");
+                if let Ok(ev) = py.detach(move || receiver.recv()) {
+                    self.variable_events = Some(ev);
                 }
             }
             self.join();
@@ -579,11 +616,33 @@ mod python_bindings {
             }
         }
 
-        /// The final interpreter state (axes, symbol_table, translation),
-        /// available once the iterator is exhausted.
+        /// The final interpreter state
+        /// (`{axes, symbol_table, translation, string_table}`), available once
+        /// the iterator is exhausted.
         #[getter]
-        fn state(&self) -> Option<FinalState> {
-            self.state.clone()
+        fn state<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
+            self.state.as_ref().map(|s| final_state_to_py(py, s)).transpose()
+        }
+
+        /// The sparse variable-change events (`include_variables=True`) as an
+        /// Arrow record batch with columns `row_idx` (Int64, the output-row
+        /// index the change is seen at), `name_id` (Int64, index into
+        /// `variable_names`) and `value` (Float64). `None` when the iterator was
+        /// created without `include_variables`. Available once exhausted.
+        /// `pl.DataFrame(it.variable_events)` wraps it zero-copy.
+        #[getter]
+        fn variable_events(&self) -> PyResult<Option<ArrowBatch>> {
+            self.variable_events
+                .as_ref()
+                .map(|ev| table_to_arrow_batch(ev.to_table()))
+                .transpose()
+        }
+
+        /// The variable names `name_id` indexes into (in first-seen order).
+        /// `None` unless `include_variables` was set; available once exhausted.
+        #[getter]
+        fn variable_names(&self) -> Option<Vec<String>> {
+            self.variable_events.as_ref().map(|ev| ev.names.clone())
         }
     }
 
@@ -593,7 +652,7 @@ mod python_bindings {
     /// thread. Wrapping each with `pl.DataFrame` and concatenating reconstructs
     /// `nc_to_dataframe`.
     #[pyfunction]
-    #[pyo3(signature = (input, batch_size = 500_000, initial_state = None, axis_identifiers = None, extra_axes = None, iteration_limit = 10000, disable_forward_fill = false, axis_index_map = None, allow_undefined_variables = false, input_is_path = false, flatten_tolerance = None, include_line_numbers = false))]
+    #[pyo3(signature = (input, batch_size = 500_000, initial_state = None, axis_identifiers = None, extra_axes = None, iteration_limit = 10000, disable_forward_fill = false, axis_index_map = None, allow_undefined_variables = false, input_is_path = false, flatten_tolerance = None, include_line_numbers = false, include_variables = false))]
     #[allow(clippy::too_many_arguments)]
     fn nc_to_batches(
         input: String,
@@ -608,6 +667,7 @@ mod python_bindings {
         input_is_path: bool,
         flatten_tolerance: Option<f64>,
         include_line_numbers: bool,
+        include_variables: bool,
     ) -> PyResult<NcBatchIterator> {
         if batch_size == 0 {
             return Err(PyErr::new::<PyValueError, _>("batch_size must be greater than 0"));
@@ -619,7 +679,7 @@ mod python_bindings {
         } else {
             input
         };
-        let (batch_receiver, result_receiver, handle) = spawn_batch_stream(
+        let (batch_receiver, result_receiver, events_receiver, handle) = spawn_batch_stream(
             input,
             batch_size,
             initial_state,
@@ -631,13 +691,22 @@ mod python_bindings {
             allow_undefined_variables,
             flatten_tolerance,
             include_line_numbers,
+            include_variables,
         )?;
 
         Ok(NcBatchIterator {
             batches: Some(Mutex::new(batch_receiver)),
             result: Some(Mutex::new(result_receiver)),
+            // Only hold the events receiver when recording; otherwise leave it
+            // `None` so `.variable_events` stays `None`.
+            events: if include_variables {
+                Some(Mutex::new(events_receiver))
+            } else {
+                None
+            },
             handle: Some(handle),
             state: None,
+            variable_events: None,
         })
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -126,6 +126,53 @@ pub struct Row {
     pub variable_changes: Vec<(String, f64)>,
 }
 
+/// Sparse side-table of variable-change events for the batch path, mirroring
+/// what the streaming `nc_to_rows` yields per row as `variable_changes`. Stored
+/// columnar (struct-of-arrays) so it converts to an Arrow table cheaply:
+///
+/// * `row_idx[i]` - the index (0-based, global across batches) of the output
+///   row this change is seen at / precedes. A change on an output row gets that
+///   row's own index; a change on a variable-only block (no output row) is
+///   attributed to the *next* output row, so replaying every event with
+///   `row_idx <= k` reconstructs the symbol table as of output row `k`.
+/// * `name_id[i]` - index into `names` (interned per run, stable, global).
+/// * `value[i]` - the new numeric value assigned.
+///
+/// Emitting is opt-in (`include_variables`); off, the batch path records
+/// nothing (no allocation), exactly as before.
+#[derive(Debug, Default, Clone)]
+pub struct VariableEvents {
+    pub row_idx: Vec<u32>,
+    pub name_id: Vec<u32>,
+    pub value: Vec<f64>,
+    pub names: Vec<String>,
+}
+
+impl VariableEvents {
+    /// Render the events as an output [`Table`]: `row_idx`/`name_id` as Int64
+    /// columns, `value` as Float64. The names list is exposed separately (as a
+    /// Python list) so `name_id` indexes into it.
+    #[allow(dead_code)] // used by the python-feature bindings, not the bin
+    pub fn to_table(&self) -> Table {
+        Table {
+            columns: vec![
+                (
+                    "row_idx".to_string(),
+                    Column::Int(self.row_idx.iter().map(|&v| Some(v as i64)).collect()),
+                ),
+                (
+                    "name_id".to_string(),
+                    Column::Int(self.name_id.iter().map(|&v| Some(v as i64)).collect()),
+                ),
+                (
+                    "value".to_string(),
+                    Column::Float(self.value.iter().map(|&v| Some(v)).collect()),
+                ),
+            ],
+        }
+    }
+}
+
 /// Where finished rows go: collected for the batch table, or pushed into a
 /// bounded channel that a streaming consumer drains while interpretation is
 /// still running.
@@ -154,21 +201,63 @@ pub struct BatchStreamSink {
     builder: BatchBuilder,
     buffer: Vec<Row>,
     batch_size: usize,
+    /// Whether to accumulate variable-change events (opt-in `include_variables`).
+    record_variables: bool,
+    /// Unbounded channel the accumulated [`VariableEvents`] are sent on once, at
+    /// finish. Unbounded so the send never blocks the worker (the events are
+    /// small and only read after the batch stream is drained).
+    events_sender: std::sync::mpsc::Sender<VariableEvents>,
+    /// Growing sparse event log, sent whole at finish.
+    events: VariableEvents,
+    /// Interned variable-name -> `name_id`, stable across the run.
+    name_ids: HashMap<String, u32>,
+    /// Count of cell-bearing (output) rows emitted so far - the `row_idx` a
+    /// change is attributed to (see [`VariableEvents`]).
+    output_row_count: u32,
 }
 
 impl BatchStreamSink {
     /// Buffer a finished row and flush a batch once `batch_size` cell-bearing
     /// rows have accumulated. Variable-only rows carry no output cells and are
-    /// dropped (they never reach the batch table).
+    /// dropped from the batch table, but their variable changes are still
+    /// recorded into the sparse event log when `record_variables` is on.
     fn accept(&mut self, row: Row) -> Result<(), ParsingError> {
+        if self.record_variables {
+            for (name, value) in &row.variable_changes {
+                let id = match self.name_ids.get(name) {
+                    Some(&id) => id,
+                    None => {
+                        let id = self.events.names.len() as u32;
+                        self.events.names.push(name.clone());
+                        self.name_ids.insert(name.clone(), id);
+                        id
+                    }
+                };
+                // Recorded at the current output-row count: a change on this row
+                // (before the increment below) gets its own index; a change on a
+                // variable-only row gets the next output row's index.
+                self.events.row_idx.push(self.output_row_count);
+                self.events.name_id.push(id);
+                self.events.value.push(*value);
+            }
+        }
         if row.cells.is_empty() {
             return Ok(());
         }
+        self.output_row_count += 1;
         self.buffer.push(row);
         if self.buffer.len() >= self.batch_size {
             self.emit()?;
         }
         Ok(())
+    }
+
+    /// Send the accumulated variable-change events once, at finish. A no-op when
+    /// not recording. Best-effort: a hung-up consumer just misses the events.
+    fn send_events(&mut self) {
+        if self.record_variables {
+            let _ = self.events_sender.send(std::mem::take(&mut self.events));
+        }
     }
 
     /// Build and send the buffered rows as one [`Table`], threading the
@@ -232,21 +321,34 @@ impl OutputRows {
     /// table drops variable-only rows), so this behaves like the collect path
     /// for parallelization purposes.
     #[allow(dead_code)] // used by the python-feature bindings, not the bin
+    #[allow(clippy::too_many_arguments)]
     pub fn batch_stream(
         sender: std::sync::mpsc::SyncSender<Table>,
         batch_size: usize,
         disable_forward_fill: bool,
+        record_variables: bool,
+        events_sender: std::sync::mpsc::Sender<VariableEvents>,
     ) -> Self {
         // Back-compatible entry point: never emits line_no.
-        Self::batch_stream_with_line_numbers(sender, batch_size, disable_forward_fill, false)
+        Self::batch_stream_with_line_numbers(
+            sender,
+            batch_size,
+            disable_forward_fill,
+            record_variables,
+            events_sender,
+            false,
+        )
     }
 
     /// As [`batch_stream`](Self::batch_stream), but with the opt-in `line_no`
     /// column. Separate constructor so `batch_stream`'s signature stays stable.
+    #[allow(clippy::too_many_arguments)]
     pub fn batch_stream_with_line_numbers(
         sender: std::sync::mpsc::SyncSender<Table>,
         batch_size: usize,
         disable_forward_fill: bool,
+        record_variables: bool,
+        events_sender: std::sync::mpsc::Sender<VariableEvents>,
         emit_line_no: bool,
     ) -> Self {
         OutputRows {
@@ -256,8 +358,15 @@ impl OutputRows {
                 builder: BatchBuilder::new(disable_forward_fill).with_line_numbers(emit_line_no),
                 buffer: Vec::new(),
                 batch_size,
+                record_variables,
+                events_sender,
+                events: VariableEvents::default(),
+                name_ids: HashMap::new(),
+                output_row_count: 0,
             }),
-            record_variables: false,
+            // Recording variable deltas on rows is what feeds the batch event
+            // log: on only when the caller opted in via `include_variables`.
+            record_variables,
             flattener: None,
             warned_g91: false,
         }
@@ -362,6 +471,7 @@ impl OutputRows {
             // full batch), then close the channel by dropping the sender.
             RowSink::Batch(mut sink) => {
                 sink.emit()?;
+                sink.send_events();
                 Ok(Vec::new())
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -288,14 +288,31 @@ impl State {
         }
     }
 
+    /// Snapshot the end-of-run state for the Python-facing `.state` dict. The
+    /// numeric maps (`axes`, `symbol_table`, `translation`) and the string
+    /// variables (`string_table`, from `DEF STRING`) are carried apart because
+    /// they have different value types; the Python binding renders them as one
+    /// dict `{axes, symbol_table, translation, string_table}`.
     #[allow(dead_code)]
-    pub fn to_python_dict(&self) -> HashMap<String, HashMap<String, f64>> {
-        let mut result = HashMap::new();
-
-        result.insert("axes".to_string(), self.axes.clone());
-        result.insert("symbol_table".to_string(), self.symbol_table.clone());
-        result.insert("translation".to_string(), self.translation.clone());
-
-        result
+    pub fn final_state(&self) -> FinalState {
+        FinalState {
+            axes: self.axes.clone(),
+            symbol_table: self.symbol_table.clone(),
+            translation: self.translation.clone(),
+            string_table: self.string_table.clone(),
+        }
     }
+}
+
+/// End-of-run interpreter state handed to Python as the `.state` dict. The
+/// numeric sub-tables keep their `f64` values; `string_table` carries the
+/// `DEF STRING` variables (a numeric sub-dict cannot hold them). The Python
+/// binding turns this into `{axes, symbol_table, translation, string_table}`.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)] // fields read only by the python-feature bindings, not the bin
+pub struct FinalState {
+    pub axes: HashMap<String, f64>,
+    pub symbol_table: HashMap<String, f64>,
+    pub translation: HashMap<String, f64>,
+    pub string_table: HashMap<String, String>,
 }


### PR DESCRIPTION
Closes #46 (I-2).

Based on `main`; independent of the line_no PRs (#51 superseded by #52).

## What
1. **Variable-change events on the batch path.** `nc_to_batches(..., include_variables=True)` now exposes, once the iterator is exhausted, a sparse `variable_events` DataFrame (`row_idx` / `name_id` / `value`) plus a `variable_names` list — the batch-path twin of the per-row `variables` dict `nc_to_rows(include_variables=True)` already yields. `row_idx` is the output-row index a change is seen at (a change on a variable-only block is attributed to the *next* output row), so replaying the events reconstructs the symbol table at any row. Off by default → zero cost when not requested. Events are accumulated in the batch sink and sent once over an unbounded channel (never blocks the worker).
2. **`string_table` in the state dict.** `DEF STRING` variables now round-trip into `.state` / the `nc_to_dataframe` state tuple as `state["string_table"]` (`dict[str, str]`), alongside the existing numeric `axes` / `symbol_table` / `translation`. `State::to_python_dict` is replaced by `State::final_state() -> FinalState` (a struct carrying the three numeric maps + the string map); the Python binding renders it as one dict — the mixed value types can't live in the old `HashMap<String, HashMap<String, f64>>`.

## Consumer
ribweaver `/sim` variable-state inspector + `sim_var:*` graph channels (snapshot + replay).

## Tests
- `python/tests/test_batch_variables.py` (8 tests): batch var-events **parity** with the streaming path (incl. a WHILE loop with a per-iteration counter), `row_idx` alignment + replay-to-final-state, absent-without-flag, empty-when-no-assignments, `string_table` round-trip on both iterators + `nc_to_dataframe`.
- `cargo test` green (49 passed, 2 ignored perf); full `pytest` green (312 passed, 4 skipped).

## Compat
Additive only. Existing `.state` consumers keep `axes`/`symbol_table`/`translation`; the batch path is unchanged unless `include_variables=True` is passed.
