### PR TITLE
chore: cargo fmt the tree + enforce cargo fmt --check in CI

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,7 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      # Pin the toolchain and explicitly pull in rustfmt so `cargo fmt --check`
+      # does not depend on whatever components the runner image ships with.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: Check Rust formatting
+        run: cargo fmt --check
       - name: Run Rust unit and integration tests
         run: cargo test
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,13 +2,15 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ParsingError {
-    #[error(r#"
+    #[error(
+        r#"
 Parse error in {context} on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: {message}
-"#)]
+"#
+    )]
     ParsingContext {
         line_no: usize,
         /// 1-based column of the offending token when known (syntax errors
@@ -19,20 +21,23 @@ Details: {message}
         context: String,
         message: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Parse error in array indexing on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: Invalid array index '{variable}'.
 This error occurs when using a variable as an array index, but the variable is not defined.
-"#)]
-    UnknownVariable { 
+"#
+    )]
+    UnknownVariable {
         line_no: usize,
         preview: String,
-        variable: String 
+        variable: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Parse error in assignment on line {line_no}
 ----------------------------------------
 Line: {preview}
@@ -43,19 +48,22 @@ To fix this, make sure to define the variable before using it. This can
 be done by adding common definitions to an initial state file, or by
 setting the `allow_undefined_variables` flag to true (this will initialize
 undefined variables to 0.0).
-"#)]
+"#
+    )]
     UndefinedVariable {
         line_no: usize,
         preview: String,
         name: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Unexpected rule '{rule:?}' encountered in {context} on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: {message}
-"#)]
+"#
+    )]
     UnexpectedRule {
         rule: crate::types::Rule,
         context: String,
@@ -75,14 +83,16 @@ Details: {message}
     LoopLimit { limit: String },
     #[error("row stream closed by the consumer")]
     StreamClosed,
-    #[error(r#"
+    #[error(
+        r#"
 Too many M commands in a single block on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: {message}
 To fix this, ensure that each block contains at most one M command.
-"#)]
+"#
+    )]
     TooManyMCommands {
         line_no: usize,
         preview: String,
@@ -94,46 +104,53 @@ To fix this, ensure that each block contains at most one M command.
     AxisUsedAsVariable { name: String },
     #[error("Cannot define a variable named '{name}', as it is a reserved block address (spline PW/SD/PL)")]
     ReservedNameUsedAsVariable { name: String },
-    #[error(r#"
+    #[error(
+        r#"
 Missing axis mapping on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: No mapping found for axis '{axis}' in array indexing operation.
-To fix this, provide an axis_index_map that includes '{axis}'."#)]
+To fix this, provide an axis_index_map that includes '{axis}'."#
+    )]
     MissingAxisMapping {
         line_no: usize,
         preview: String,
         axis: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Invalid axis mapping on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: Invalid index {index} for axis '{axis}' in array indexing operation.
-Array indices must be non-negative and within the valid range."#)]
+Array indices must be non-negative and within the valid range."#
+    )]
     InvalidAxisIndex {
         line_no: usize,
         preview: String,
         axis: String,
         index: usize,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Unsupported statement on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: {statement} is not supported by this interpreter.
 {hint}
-"#)]
+"#
+    )]
     UnsupportedStatement {
         line_no: usize,
         preview: String,
         statement: String,
         hint: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Jump destination not found on line {line_no}
 ----------------------------------------
 Line: {preview}
@@ -142,7 +159,8 @@ Details: No block with the jump label or block number '{target}' was found
 searching {search_direction} (alarm 14080 on a real control).{hint}
 Note: jump destinations inside IF/LOOP/FOR/WHILE/REPEAT bodies cannot be
 reached from outside those bodies.
-"#)]
+"#
+    )]
     JumpTargetNotFound {
         line_no: usize,
         preview: String,
@@ -151,19 +169,22 @@ reached from outside those bodies.
         /// Either empty or a "\nDid you mean '...'?" suggestion line.
         hint: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Unmatched control structure on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: {message}.
-"#)]
+"#
+    )]
     UnmatchedStructure {
         line_no: usize,
         preview: String,
         message: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Unknown G code on line {line_no}
 ----------------------------------------
 Line: {preview}
@@ -171,19 +192,22 @@ Line: {preview}
 Details: '{code}' is not a G code known to this interpreter (a real control
 raises alarm 12470 "undefined G function"). If this is meant to be a
 subprogram call, note that program names cannot look like a G code.
-"#)]
+"#
+    )]
     UnknownGCommand {
         line_no: usize,
         preview: String,
         code: String,
     },
-    #[error(r#"
+    #[error(
+        r#"
 Invalid function call on line {line_no}
 ----------------------------------------
 Line: {preview}
 
 Details: Function {name} expects {expected} argument(s), but received {actual}.
-"#)]
+"#
+    )]
     InvalidFunctionArity {
         line_no: usize,
         preview: String,
@@ -210,12 +234,7 @@ pub struct ErrorLocation {
 }
 
 impl ParsingError {
-    pub fn with_context<T: AsRef<str>>(
-        line_no: usize,
-        preview: T,
-        context: T,
-        message: T,
-    ) -> Self {
+    pub fn with_context<T: AsRef<str>>(line_no: usize, preview: T, context: T, message: T) -> Self {
         Self::ParsingContext {
             line_no,
             column: None,
@@ -230,10 +249,7 @@ impl ParsingError {
     /// etc.). `line_text`/`context`/`column` are populated when the variant
     /// carries them.
     pub fn location(&self) -> Option<ErrorLocation> {
-        let some = |line: usize,
-                    column: Option<usize>,
-                    context: Option<&str>,
-                    preview: Option<&str>| {
+        let some = |line: usize, column: Option<usize>, context: Option<&str>, preview: Option<&str>| {
             Some(ErrorLocation {
                 line,
                 column,
@@ -242,12 +258,19 @@ impl ParsingError {
             })
         };
         match self {
-            Self::ParsingContext { line_no, column, preview, context, .. } => {
-                some(*line_no, *column, Some(context), Some(preview))
-            }
-            Self::UnexpectedRule { line_no, preview, context, .. } => {
-                some(*line_no, None, Some(context), Some(preview))
-            }
+            Self::ParsingContext {
+                line_no,
+                column,
+                preview,
+                context,
+                ..
+            } => some(*line_no, *column, Some(context), Some(preview)),
+            Self::UnexpectedRule {
+                line_no,
+                preview,
+                context,
+                ..
+            } => some(*line_no, None, Some(context), Some(preview)),
             Self::UnknownVariable { line_no, preview, .. }
             | Self::UndefinedVariable { line_no, preview, .. }
             | Self::TooManyMCommands { line_no, preview, .. }
@@ -257,9 +280,7 @@ impl ParsingError {
             | Self::JumpTargetNotFound { line_no, preview, .. }
             | Self::UnmatchedStructure { line_no, preview, .. }
             | Self::UnknownGCommand { line_no, preview, .. }
-            | Self::InvalidFunctionArity { line_no, preview, .. } => {
-                some(*line_no, None, None, Some(preview))
-            }
+            | Self::InvalidFunctionArity { line_no, preview, .. } => some(*line_no, None, None, Some(preview)),
             Self::ParseError { .. }
             | Self::InvalidElementCount { .. }
             | Self::InvalidCondition

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -106,9 +106,18 @@ struct Plane {
     offsets: [&'static str; 2],
 }
 
-const G17: Plane = Plane { axes: ["X", "Y"], offsets: ["I", "J"] };
-const G18: Plane = Plane { axes: ["Z", "X"], offsets: ["K", "I"] };
-const G19: Plane = Plane { axes: ["Y", "Z"], offsets: ["J", "K"] };
+const G17: Plane = Plane {
+    axes: ["X", "Y"],
+    offsets: ["I", "J"],
+};
+const G18: Plane = Plane {
+    axes: ["Z", "X"],
+    offsets: ["K", "I"],
+};
+const G19: Plane = Plane {
+    axes: ["Y", "Z"],
+    offsets: ["J", "K"],
+};
 
 /// One buffered block of an active spline: either a point-bearing row (its
 /// geometric axis cells define the next spline point / control point) or any
@@ -297,10 +306,7 @@ impl Flattener {
             return;
         }
 
-        let (Some(su), Some(sv)) = (
-            self.positions.get(u_axis).copied(),
-            self.positions.get(v_axis).copied(),
-        ) else {
+        let (Some(su), Some(sv)) = (self.positions.get(u_axis).copied(), self.positions.get(v_axis).copied()) else {
             self.pass_through_with_warning(row, "arc start position is unknown", out);
             return;
         };
@@ -439,7 +445,11 @@ impl Flattener {
                 let value = if k == segments { end } else { start + (end - start) * f };
                 cells.insert(axis, Value::Float(value));
             }
-            emitted.push(Row { line_no: row.line_no, cells, variable_changes: Vec::new() });
+            emitted.push(Row {
+                line_no: row.line_no,
+                cells,
+                variable_changes: Vec::new(),
+            });
         }
 
         let mut geometry: Vec<&'static str> = vec![u_axis, v_axis];
@@ -525,7 +535,11 @@ impl Flattener {
                 .filter(|(_, c)| METRIC_AXES.contains(&**c))
                 .map(|(i, _)| i)
                 .collect();
-            if xyz.is_empty() { (0..channels.len()).collect() } else { xyz }
+            if xyz.is_empty() {
+                (0..channels.len()).collect()
+            } else {
+                xyz
+            }
         };
 
         // Sample the curve: per source point, the run of samples that ends
@@ -537,9 +551,7 @@ impl Flattener {
                 SplineKind::Akima | SplineKind::Cubic => {
                     interpolating_spline_runs(&points, &metric, self.tolerance, kind)
                 }
-                SplineKind::BSpline => {
-                    bspline_runs(&points, &weights, self.spline_degree, &metric, self.tolerance)
-                }
+                SplineKind::BSpline => bspline_runs(&points, &weights, self.spline_degree, &metric, self.tolerance),
             }
         };
 
@@ -583,7 +595,11 @@ impl Flattener {
                                 }
                             }
                         }
-                        emitted.push(Row { line_no: row.line_no, cells, variable_changes: Vec::new() });
+                        emitted.push(Row {
+                            line_no: row.line_no,
+                            cells,
+                            variable_changes: Vec::new(),
+                        });
                     } else {
                         for (si, sample) in samples.iter().enumerate() {
                             let mut cells = CellMap::default();
@@ -611,7 +627,9 @@ impl Flattener {
                     merge_aux_cells(&row, &mut emitted[0], &channels);
                     emitted[0].variable_changes = row.variable_changes.clone();
                     if first_motion_pending {
-                        emitted[0].cells.insert(intern_column("gg01_motion"), Value::Str("G1".to_string()));
+                        emitted[0]
+                            .cells
+                            .insert(intern_column("gg01_motion"), Value::Str("G1".to_string()));
                         first_motion_pending = false;
                     } else {
                         // A restated spline command mid-run must not leak into
@@ -721,9 +739,7 @@ fn adaptive_flatten(
     let pm = eval(tm);
     let within = |p: &[f64]| deviation(p, p0, p1, metric) <= tol;
     let ok = depth >= MAX_SUBDIV_DEPTH
-        || (within(&pm)
-            && within(&eval(t0 + 0.25 * (t1 - t0)))
-            && within(&eval(t0 + 0.75 * (t1 - t0))));
+        || (within(&pm) && within(&eval(t0 + 0.25 * (t1 - t0))) && within(&eval(t0 + 0.75 * (t1 - t0))));
     if ok {
         out.push(p1.to_vec());
     } else {
@@ -802,8 +818,12 @@ fn interpolating_spline_runs(
         let h = fit_ts[seg + 1] - fit_ts[seg];
         let s = ((t - fit_ts[seg]) / h).clamp(0.0, 1.0);
         let (s2, s3) = (s * s, s * s * s);
-        let (h00, h10, h01, h11) =
-            (2.0 * s3 - 3.0 * s2 + 1.0, s3 - 2.0 * s2 + s, -2.0 * s3 + 3.0 * s2, s3 - s2);
+        let (h00, h10, h01, h11) = (
+            2.0 * s3 - 3.0 * s2 + 1.0,
+            s3 - 2.0 * s2 + s,
+            -2.0 * s3 + 3.0 * s2,
+            s3 - s2,
+        );
         (0..channels)
             .map(|c| {
                 h00 * fit_points[seg][c]
@@ -822,7 +842,17 @@ fn interpolating_spline_runs(
             runs.push(vec![points[i + 1].clone()]);
         } else {
             let mut run = Vec::new();
-            adaptive_flatten(&eval, ts[i], &points[i], ts[i + 1], &points[i + 1], tol, metric, 0, &mut run);
+            adaptive_flatten(
+                &eval,
+                ts[i],
+                &points[i],
+                ts[i + 1],
+                &points[i + 1],
+                tol,
+                metric,
+                0,
+                &mut run,
+            );
             runs.push(run);
         }
     }
@@ -955,7 +985,11 @@ fn bspline_runs(
             for j in (r..=p).rev() {
                 let i = j + k - p;
                 let denom = knots[i + p + 1 - r] - knots[i];
-                let alpha = if denom.abs() < 1e-30 { 0.0 } else { (t - knots[i]) / denom };
+                let alpha = if denom.abs() < 1e-30 {
+                    0.0
+                } else {
+                    (t - knots[i]) / denom
+                };
                 // Indexing two rows of `d` at once: a plain indexed loop is
                 // clearer than a split_at_mut dance.
                 #[allow(clippy::needless_range_loop)]
@@ -994,7 +1028,10 @@ mod tests {
     use super::*;
 
     fn axis_ids() -> Vec<String> {
-        ["X", "Y", "Z", "A", "E", "F", "S", "N"].iter().map(|s| s.to_string()).collect()
+        ["X", "Y", "Z", "A", "E", "F", "S", "N"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
     }
 
     fn flattener(tol: f64) -> Flattener {
@@ -1006,7 +1043,11 @@ mod tests {
         for (key, value) in cells {
             map.insert(intern_column(key), value.clone());
         }
-        Row { line_no, cells: map, variable_changes: Vec::new() }
+        Row {
+            line_no,
+            cells: map,
+            variable_changes: Vec::new(),
+        }
     }
 
     fn f(v: f64) -> Value {
@@ -1048,7 +1089,16 @@ mod tests {
         let mut fl = flattener(tol);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("X", f(100.0)), ("Y", f(0.0)), ("I", f(50.0)), ("J", f(0.0))]),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G2")),
+                    ("X", f(100.0)),
+                    ("Y", f(0.0)),
+                    ("I", f(50.0)),
+                    ("J", f(0.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         assert!(out.len() > 10, "expected a sampled run, got {} rows", out.len());
@@ -1072,7 +1122,9 @@ mod tests {
         }
         // Motion rewritten to G1 on the first emitted row, I/J consumed.
         assert!(matches!(out[1].cells.get("gg01_motion"), Some(Value::Str(m)) if m == "G1"));
-        assert!(out.iter().all(|r| r.cells.get("I").is_none() && r.cells.get("J").is_none()));
+        assert!(out
+            .iter()
+            .all(|r| r.cells.get("I").is_none() && r.cells.get("J").is_none()));
     }
 
     #[test]
@@ -1080,7 +1132,16 @@ mod tests {
         let mut fl = flattener(0.01);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("G3")), ("X", f(100.0)), ("Y", f(0.0)), ("I", f(50.0)), ("J", f(0.0))]),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G3")),
+                    ("X", f(100.0)),
+                    ("Y", f(0.0)),
+                    ("I", f(50.0)),
+                    ("J", f(0.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         assert!(out[2..].iter().all(|r| cell_float(r, "Y").unwrap() <= 1e-9));
@@ -1091,7 +1152,16 @@ mod tests {
         let mut fl = flattener(0.1);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("X", f(0.0)), ("Y", f(0.0)), ("I", f(25.0)), ("J", f(0.0))]),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G2")),
+                    ("X", f(0.0)),
+                    ("Y", f(0.0)),
+                    ("I", f(25.0)),
+                    ("J", f(0.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         // Sweep of 2*pi at r=25 with tol=0.1: at least 20-some segments.
@@ -1106,22 +1176,42 @@ mod tests {
         let mut fl = flattener(0.01);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("X", f(40.0)), ("Y", f(0.0)), ("CR", f(20.0))]),
+            row(
+                2,
+                &[("gg01_motion", s("G2")), ("X", f(40.0)), ("Y", f(0.0)), ("CR", f(20.0))],
+            ),
         ];
         let out = run(&mut fl, rows);
         // CR=20 with chord 40: semicircle, clockwise -> over the top, apex +20.
-        let max_y = out[1..].iter().map(|r| cell_float(r, "Y").unwrap()).fold(f64::MIN, f64::max);
-        assert!((max_y - 20.0).abs() < 0.05, "expected semicircle apex at +20, got {max_y}");
+        let max_y = out[1..]
+            .iter()
+            .map(|r| cell_float(r, "Y").unwrap())
+            .fold(f64::MIN, f64::max);
+        assert!(
+            (max_y - 20.0).abs() < 0.05,
+            "expected semicircle apex at +20, got {max_y}"
+        );
         assert_eq!(xy(out.last().unwrap()), (40.0, 0.0));
 
         // Negative CR selects the major arc: sweep > half turn.
         let mut fl = flattener(0.01);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("X", f(20.0)), ("Y", f(0.0)), ("CR", f(-20.0))]),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G2")),
+                    ("X", f(20.0)),
+                    ("Y", f(0.0)),
+                    ("CR", f(-20.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
-        let max_y = out[1..].iter().map(|r| cell_float(r, "Y").unwrap()).fold(f64::MIN, f64::max);
+        let max_y = out[1..]
+            .iter()
+            .map(|r| cell_float(r, "Y").unwrap())
+            .fold(f64::MIN, f64::max);
         assert!(max_y > 30.0, "major arc should swing well above the chord, got {max_y}");
     }
 
@@ -1129,8 +1219,21 @@ mod tests {
     fn helical_arc_interpolates_z_linearly() {
         let mut fl = flattener(0.01);
         let rows = vec![
-            row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(10.0)), ("I", f(25.0)), ("J", f(0.0))]),
+            row(
+                1,
+                &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))],
+            ),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G2")),
+                    ("X", f(0.0)),
+                    ("Y", f(0.0)),
+                    ("Z", f(10.0)),
+                    ("I", f(25.0)),
+                    ("J", f(0.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         let zs: Vec<f64> = out[1..].iter().map(|r| cell_float(r, "Z").unwrap()).collect();
@@ -1147,8 +1250,26 @@ mod tests {
     fn g18_arc_uses_zx_plane() {
         let mut fl = flattener(0.01);
         let rows = vec![
-            row(1, &[("gg01_motion", s("G1")), ("gg06_plane_select", s("G18")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("Z", f(0.0)), ("X", f(40.0)), ("K", f(0.0)), ("I", f(20.0))]),
+            row(
+                1,
+                &[
+                    ("gg01_motion", s("G1")),
+                    ("gg06_plane_select", s("G18")),
+                    ("X", f(0.0)),
+                    ("Y", f(0.0)),
+                    ("Z", f(0.0)),
+                ],
+            ),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G2")),
+                    ("Z", f(0.0)),
+                    ("X", f(40.0)),
+                    ("K", f(0.0)),
+                    ("I", f(20.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         assert!(out.len() > 5);
@@ -1165,8 +1286,26 @@ mod tests {
     fn g19_arc_uses_yz_plane() {
         let mut fl = flattener(0.01);
         let rows = vec![
-            row(1, &[("gg01_motion", s("G1")), ("gg06_plane_select", s("G19")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))]),
-            row(2, &[("gg01_motion", s("G3")), ("Y", f(40.0)), ("Z", f(0.0)), ("J", f(20.0)), ("K", f(0.0))]),
+            row(
+                1,
+                &[
+                    ("gg01_motion", s("G1")),
+                    ("gg06_plane_select", s("G19")),
+                    ("X", f(0.0)),
+                    ("Y", f(0.0)),
+                    ("Z", f(0.0)),
+                ],
+            ),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G3")),
+                    ("Y", f(40.0)),
+                    ("Z", f(0.0)),
+                    ("J", f(20.0)),
+                    ("K", f(0.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         assert!(out.len() > 5);
@@ -1178,7 +1317,10 @@ mod tests {
             assert!(r.cells.get("X").is_none());
         }
         assert_eq!(
-            (cell_float(out.last().unwrap(), "Y").unwrap(), cell_float(out.last().unwrap(), "Z").unwrap()),
+            (
+                cell_float(out.last().unwrap(), "Y").unwrap(),
+                cell_float(out.last().unwrap(), "Z").unwrap()
+            ),
             (40.0, 0.0)
         );
     }
@@ -1189,11 +1331,20 @@ mod tests {
         let mut fl = flattener(0.01);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("G3")), ("X", f(40.0)), ("Y", f(0.0)), ("CR", f(20.0))]),
+            row(
+                2,
+                &[("gg01_motion", s("G3")), ("X", f(40.0)), ("Y", f(0.0)), ("CR", f(20.0))],
+            ),
         ];
         let out = run(&mut fl, rows);
-        let min_y = out[1..].iter().map(|r| cell_float(r, "Y").unwrap()).fold(f64::MAX, f64::min);
-        assert!((min_y + 20.0).abs() < 0.05, "G3 semicircle should dip to -20, got {min_y}");
+        let min_y = out[1..]
+            .iter()
+            .map(|r| cell_float(r, "Y").unwrap())
+            .fold(f64::MAX, f64::min);
+        assert!(
+            (min_y + 20.0).abs() < 0.05,
+            "G3 semicircle should dip to -20, got {min_y}"
+        );
         assert_eq!(xy(out.last().unwrap()), (40.0, 0.0));
     }
 
@@ -1201,8 +1352,26 @@ mod tests {
     fn full_circle_in_g18() {
         let mut fl = flattener(0.1);
         let rows = vec![
-            row(1, &[("gg01_motion", s("G1")), ("gg06_plane_select", s("G18")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))]),
-            row(2, &[("gg01_motion", s("G2")), ("Z", f(0.0)), ("X", f(0.0)), ("K", f(25.0)), ("I", f(0.0))]),
+            row(
+                1,
+                &[
+                    ("gg01_motion", s("G1")),
+                    ("gg06_plane_select", s("G18")),
+                    ("X", f(0.0)),
+                    ("Y", f(0.0)),
+                    ("Z", f(0.0)),
+                ],
+            ),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("G2")),
+                    ("Z", f(0.0)),
+                    ("X", f(0.0)),
+                    ("K", f(25.0)),
+                    ("I", f(0.0)),
+                ],
+            ),
         ];
         let out = run(&mut fl, rows);
         assert!(out.len() > 20, "full circle in G18 under-sampled: {}", out.len());
@@ -1229,7 +1398,10 @@ mod tests {
             run(
                 &mut fl,
                 vec![
-                    row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))]),
+                    row(
+                        1,
+                        &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0)), ("Z", f(0.0))],
+                    ),
                     row(2, &cells),
                 ],
             )
@@ -1238,7 +1410,11 @@ mod tests {
         let out = helix(Some(2.0));
         // Sweep of 3 full circles instead of 1: ~3x the samples, and X crosses
         // the far side of the circle 3 times.
-        assert!(out.len() > 2 * single, "TURN=2 should triple the sweep: {} vs {single}", out.len());
+        assert!(
+            out.len() > 2 * single,
+            "TURN=2 should triple the sweep: {} vs {single}",
+            out.len()
+        );
         let far_crossings = out[1..]
             .windows(2)
             .filter(|w| {
@@ -1247,7 +1423,10 @@ mod tests {
                 (a < 49.0) != (b < 49.0)
             })
             .count();
-        assert!(far_crossings >= 5, "expected 3 far-side passes, got {far_crossings} crossings");
+        assert!(
+            far_crossings >= 5,
+            "expected 3 far-side passes, got {far_crossings} crossings"
+        );
         // Z still lands exactly, monotonically.
         let zs: Vec<f64> = out[1..].iter().map(|r| cell_float(r, "Z").unwrap()).collect();
         assert!((zs.last().unwrap() - 30.0).abs() < 1e-9);
@@ -1263,7 +1442,16 @@ mod tests {
         let mut fl = flattener(0.01);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("CIP")), ("X", f(20.0)), ("Y", f(0.0)), ("I", f(10.0)), ("J", f(5.0))]),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("CIP")),
+                    ("X", f(20.0)),
+                    ("Y", f(0.0)),
+                    ("I", f(10.0)),
+                    ("J", f(5.0)),
+                ],
+            ),
             row(3, &[("gg01_motion", s("G1")), ("X", f(30.0)), ("Y", f(0.0))]),
         ];
         let out = run(&mut fl, rows);
@@ -1280,7 +1468,16 @@ mod tests {
                 &mut fl,
                 vec![
                     row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-                    row(2, &[("gg01_motion", s("G3")), ("X", f(100.0)), ("Y", f(0.0)), ("I", f(50.0)), ("J", f(0.0))]),
+                    row(
+                        2,
+                        &[
+                            ("gg01_motion", s("G3")),
+                            ("X", f(100.0)),
+                            ("Y", f(0.0)),
+                            ("I", f(50.0)),
+                            ("J", f(0.0)),
+                        ],
+                    ),
                 ],
             )
             .len()
@@ -1323,7 +1520,9 @@ mod tests {
         assert!(out.len() > 3);
         assert!(cell_float(&out[1], "F").is_some());
         assert!(out[1].cells.get("M").is_some());
-        assert!(out[2..].iter().all(|r| r.cells.get("F").is_none() && r.cells.get("M").is_none()));
+        assert!(out[2..]
+            .iter()
+            .all(|r| r.cells.get("F").is_none() && r.cells.get("M").is_none()));
         assert!(out.iter().all(|r| r.line_no == 1 || r.line_no == 2));
     }
 
@@ -1343,7 +1542,14 @@ mod tests {
                 (a.cos(), a.sin())
             })
             .collect();
-        rows.push(row(2, &[("gg01_motion", s("CSPLINE")), ("X", f(points[0].0)), ("Y", f(points[0].1))]));
+        rows.push(row(
+            2,
+            &[
+                ("gg01_motion", s("CSPLINE")),
+                ("X", f(points[0].0)),
+                ("Y", f(points[0].1)),
+            ],
+        ));
         for (i, (x, y)) in points.iter().enumerate().skip(1) {
             rows.push(row(3 + i, &[("X", f(*x)), ("Y", f(*y))]));
         }
@@ -1368,9 +1574,9 @@ mod tests {
             assert!((radius - 1.0).abs() < 0.02, "sample far off circle: r={radius}");
         }
         // Spline command must not survive flattening.
-        assert!(out.iter().all(
-            |r| !matches!(r.cells.get("gg01_motion"), Some(Value::Str(m)) if m.contains("SPLINE"))
-        ));
+        assert!(out
+            .iter()
+            .all(|r| !matches!(r.cells.get("gg01_motion"), Some(Value::Str(m)) if m.contains("SPLINE"))));
         // Deselecting G1 row passes through as-is.
         assert_eq!(xy(out.last().unwrap()), (0.0, 2.0));
     }
@@ -1381,7 +1587,10 @@ mod tests {
         let pts = [(10.0, 20.0), (20.0, 40.0), (30.0, 30.0), (40.0, 45.0), (50.0, 0.0)];
         let mut rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("ASPLINE")), ("X", f(pts[0].0)), ("Y", f(pts[0].1))]),
+            row(
+                2,
+                &[("gg01_motion", s("ASPLINE")), ("X", f(pts[0].0)), ("Y", f(pts[0].1))],
+            ),
         ];
         for (i, (x, y)) in pts.iter().enumerate().skip(1) {
             rows.push(row(3 + i, &[("X", f(*x)), ("Y", f(*y))]));
@@ -1484,7 +1693,15 @@ mod tests {
         let mut fl = flattener(0.001);
         let rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("BSPLINE")), ("X", f(10.0)), ("Y", f(10.0)), ("SD", f(2.0))]),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("BSPLINE")),
+                    ("X", f(10.0)),
+                    ("Y", f(10.0)),
+                    ("SD", f(2.0)),
+                ],
+            ),
             row(3, &[("X", f(20.0)), ("Y", f(0.0))]),
         ];
         let out = run(&mut fl, rows);
@@ -1503,8 +1720,19 @@ mod tests {
     fn spline_extra_channel_is_sampled() {
         let mut fl = flattener(0.01);
         let rows = vec![
-            row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0)), ("E", f(0.0))]),
-            row(2, &[("gg01_motion", s("ASPLINE")), ("X", f(10.0)), ("Y", f(10.0)), ("E", f(1.0))]),
+            row(
+                1,
+                &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0)), ("E", f(0.0))],
+            ),
+            row(
+                2,
+                &[
+                    ("gg01_motion", s("ASPLINE")),
+                    ("X", f(10.0)),
+                    ("Y", f(10.0)),
+                    ("E", f(1.0)),
+                ],
+            ),
             row(3, &[("X", f(20.0)), ("Y", f(0.0)), ("E", f(2.0))]),
             row(4, &[("X", f(30.0)), ("Y", f(10.0)), ("E", f(3.0))]),
         ];
@@ -1549,30 +1777,45 @@ mod tests {
             &mut fl,
             vec![
                 row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-                row(2, &[("gg01_motion", s("G2")), ("X", f(100.0)), ("Y", f(0.0)), ("I", f(50.0)), ("J", f(0.0))]),
+                row(
+                    2,
+                    &[
+                        ("gg01_motion", s("G2")),
+                        ("X", f(100.0)),
+                        ("Y", f(0.0)),
+                        ("I", f(50.0)),
+                        ("J", f(0.0)),
+                    ],
+                ),
             ],
         );
         assert!(!marked(&out[0]), "passthrough row must not be marked");
         assert!(out[1..out.len() - 1].iter().all(marked));
-        assert!(!marked(out.last().unwrap()), "programmed arc endpoint must not be marked");
+        assert!(
+            !marked(out.last().unwrap()),
+            "programmed arc endpoint must not be marked"
+        );
 
         // Interpolating spline: the programmed points are the unmarked rows.
         let pts = [(10.0, 20.0), (20.0, 40.0), (30.0, 30.0)];
         let mut fl = flattener(0.01);
         let mut rows = vec![
             row(1, &[("gg01_motion", s("G1")), ("X", f(0.0)), ("Y", f(0.0))]),
-            row(2, &[("gg01_motion", s("ASPLINE")), ("X", f(pts[0].0)), ("Y", f(pts[0].1))]),
+            row(
+                2,
+                &[("gg01_motion", s("ASPLINE")), ("X", f(pts[0].0)), ("Y", f(pts[0].1))],
+            ),
         ];
         for (i, (x, y)) in pts.iter().enumerate().skip(1) {
             rows.push(row(3 + i, &[("X", f(*x)), ("Y", f(*y))]));
         }
         let out = run(&mut fl, rows);
-        let unmarked: Vec<(f64, f64)> = out[1..]
-            .iter()
-            .filter(|r| !marked(r))
-            .map(|r| xy(r))
-            .collect();
-        assert_eq!(unmarked, pts.to_vec(), "unmarked rows must be exactly the programmed points");
+        let unmarked: Vec<(f64, f64)> = out[1..].iter().filter(|r| !marked(r)).map(|r| xy(r)).collect();
+        assert_eq!(
+            unmarked,
+            pts.to_vec(),
+            "unmarked rows must be exactly the programmed points"
+        );
 
         // B-spline: only the curve end (== last control point) is unmarked.
         let mut fl = flattener(0.01);
@@ -1613,8 +1856,14 @@ mod tests {
             .collect();
         let build = |tol: f64| {
             let mut fl = flattener(tol);
-            let mut rows = vec![row(1, &[("gg01_motion", s("G1")), ("X", f(pts[0].0)), ("Y", f(pts[0].1))])];
-            rows.push(row(2, &[("gg01_motion", s("CSPLINE")), ("X", f(pts[1].0)), ("Y", f(pts[1].1))]));
+            let mut rows = vec![row(
+                1,
+                &[("gg01_motion", s("G1")), ("X", f(pts[0].0)), ("Y", f(pts[0].1))],
+            )];
+            rows.push(row(
+                2,
+                &[("gg01_motion", s("CSPLINE")), ("X", f(pts[1].0)), ("Y", f(pts[1].1))],
+            ));
             for (i, (x, y)) in pts.iter().enumerate().skip(2) {
                 rows.push(row(i + 2, &[("X", f(*x)), ("Y", f(*y))]));
             }

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -140,7 +140,11 @@ pub(crate) fn canonical_jump_target(raw: &str) -> String {
 
 pub(crate) fn canonical_block_number(digits: &str) -> &str {
     let stripped = digits.trim_start_matches('0');
-    if stripped.is_empty() { "0" } else { stripped }
+    if stripped.is_empty() {
+        "0"
+    } else {
+        stripped
+    }
 }
 
 /// Collect the jump targets (labels and block numbers) defined by each block
@@ -227,14 +231,14 @@ fn interpret_primary(primary: Pair<Rule>, state: &mut State) -> Result<f64, Pars
                     state.symbol_table.insert(key, 0.0);
                     Ok(0.0)
                 } else {
-                    Err(ParsingError::UndefinedVariable { 
+                    Err(ParsingError::UndefinedVariable {
                         line_no,
                         preview,
-                        name: key 
+                        name: key,
                     })
                 }
             })
-        },
+        }
         Rule::variable_array => {
             let (line_no, preview) = get_error_context(&inner_pair, state);
             if let Some(value) = read_actual_position_sysvar(&inner_pair, state)? {
@@ -245,7 +249,10 @@ fn interpret_primary(primary: Pair<Rule>, state: &mut State) -> Result<f64, Pars
                 if let Some(value) = state.symbol_table.get(key).cloned() {
                     Ok(value)
                 } else if state.allow_undefined_variables {
-                    crate::state::emit_warning(format_args!("Warning: Variable array element '{}' is undefined, initializing to 0.0", key));
+                    crate::state::emit_warning(format_args!(
+                        "Warning: Variable array element '{}' is undefined, initializing to 0.0",
+                        key
+                    ));
                     state.symbol_table.insert(key.clone(), 0.0);
                     Ok(0.0)
                 } else {
@@ -256,7 +263,7 @@ fn interpret_primary(primary: Pair<Rule>, state: &mut State) -> Result<f64, Pars
                     })
                 }
             })
-        },
+        }
         Rule::expression => evaluate_expression(inner_pair, state),
         Rule::arith_fun => evaluate_arithmetic_function(inner_pair, state),
         _ => {
@@ -274,27 +281,25 @@ fn interpret_primary(primary: Pair<Rule>, state: &mut State) -> Result<f64, Pars
 fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f64, ParsingError> {
     let (line_no, preview) = get_error_context(&pair, state);
     let mut pairs = pair.into_inner();
-    
+
     // Get function name
-    let func_name = pairs.next()
-        .ok_or_else(|| ParsingError::ParsingContext {
-            line_no,
-            column: None,
-            preview: preview.clone(),
-            context: "function evaluation".to_string(),
-            message: "Missing function name".to_string(),
-        })?;
-    
+    let func_name = pairs.next().ok_or_else(|| ParsingError::ParsingContext {
+        line_no,
+        column: None,
+        preview: preview.clone(),
+        context: "function evaluation".to_string(),
+        message: "Missing function name".to_string(),
+    })?;
+
     // Get arguments pair
-    let args_pair = pairs.next()
-        .ok_or_else(|| ParsingError::ParsingContext {
-            line_no,
-            column: None,
-            preview: preview.clone(),
-            context: "function evaluation".to_string(),
-            message: "Missing function arguments".to_string(),
-        })?;
-    
+    let args_pair = pairs.next().ok_or_else(|| ParsingError::ParsingContext {
+        line_no,
+        column: None,
+        preview: preview.clone(),
+        context: "function evaluation".to_string(),
+        message: "Missing function arguments".to_string(),
+    })?;
+
     // Parse arguments
     let mut args = Vec::new();
     for arg in args_pair.into_inner() {
@@ -325,63 +330,63 @@ fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f
         "SIN" => {
             check_args(1)?;
             Ok(args[0].to_radians().sin())
-        },
+        }
         "COS" => {
             check_args(1)?;
             Ok(args[0].to_radians().cos())
-        },
+        }
         "TAN" => {
             check_args(1)?;
             Ok(args[0].to_radians().tan())
-        },
+        }
         "ASIN" => {
             check_args(1)?;
             Ok(args[0].asin().to_degrees())
-        },
+        }
         "ACOS" => {
             check_args(1)?;
             Ok(args[0].acos().to_degrees())
-        },
+        }
         "ATAN2" => {
             check_args(2)?;
             // ATAN2(a, b): angle of the vector sum of two perpendicular vectors,
             // in degrees (-180..180]. The angular reference is the SECOND value,
             // so e.g. ATAN2(30.5, 80.1) = 20.8455 (manual 4.1.3.1).
             Ok(args[0].atan2(args[1]).to_degrees())
-        },
+        }
         "SQRT" => {
             check_args(1)?;
             Ok(args[0].sqrt())
-        },
+        }
         "ABS" => {
             check_args(1)?;
             Ok(args[0].abs())
-        },
+        }
         "POT" => {
             check_args(1)?;
             Ok(args[0].powi(2))
-        },
+        }
         "TRUNC" => {
             check_args(1)?;
             Ok(args[0].trunc())
-        },
+        }
         "ROUND" => {
             check_args(1)?;
             Ok(args[0].round())
-        },
+        }
         "ROUNDUP" => {
             // Round up to the next higher integer (manual 4.1.3.5).
             check_args(1)?;
             Ok(args[0].ceil())
-        },
+        }
         "MINVAL" => {
             check_args(2)?;
             Ok(args[0].min(args[1]))
-        },
+        }
         "MAXVAL" => {
             check_args(2)?;
             Ok(args[0].max(args[1]))
-        },
+        }
         "BOUND" => {
             // BOUND(<minimum>, <maximum>, <check value>): the check value
             // bounded to [minimum, maximum] (manual 4.1.1.13).
@@ -397,15 +402,15 @@ fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f
                 });
             }
             Ok(value.clamp(min, max))
-        },
+        }
         "LN" => {
             check_args(1)?;
             Ok(args[0].ln())
-        },
+        }
         "EXP" => {
             check_args(1)?;
             Ok(args[0].exp())
-        },
+        }
         other => Err(ParsingError::ParsingContext {
             line_no,
             column: None,
@@ -773,7 +778,11 @@ fn interpret_assignment(element: Pair<Rule>, state: &mut State) -> Result<(Strin
                 state,
             ));
         }
-        let text = expression_pair.into_inner().next().map(|s| s.as_str().to_string()).unwrap_or_default();
+        let text = expression_pair
+            .into_inner()
+            .next()
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
         state.string_table.insert(key.clone(), text);
         return Ok((key, None));
     }
@@ -824,7 +833,10 @@ fn interpret_assignment(element: Pair<Rule>, state: &mut State) -> Result<(Strin
                 context: "interpret_assignment".to_string(),
                 line_no: expression_pair.line_col().0,
                 preview: state.get_line(expression_pair.line_col().0).unwrap_or("").to_string(),
-                message: format!("Unexpected rule in interpret_assignment: {:?}", expression_pair.as_rule()),
+                message: format!(
+                    "Unexpected rule in interpret_assignment: {:?}",
+                    expression_pair.as_rule()
+                ),
             })
         }
     };
@@ -859,14 +871,20 @@ fn interpret_axis_increment(pair: Pair<Rule>, state: &mut State, key: String) ->
     // offsets are traversed after a frame change"); machines configured with
     // FALSE traverse the pure increment instead, which is not modeled here.
     let pair_clone = pair.clone();
-    let inner_pair = pair.into_inner().next().expect("Expected an expression inside axis_increment, found none");
+    let inner_pair = pair
+        .into_inner()
+        .next()
+        .expect("Expected an expression inside axis_increment, found none");
     if inner_pair.as_rule() != Rule::expression {
         return Err(ParsingError::UnexpectedRule {
             rule: inner_pair.as_rule(),
             context: "interpret_axis_increment::axis_increment".to_string(),
             line_no: pair_clone.line_col().0,
             preview: state.get_line(pair_clone.line_col().0).unwrap_or("").to_string(),
-            message: format!("Unexpected rule in interpret_axis_increment: {:?}", inner_pair.as_rule()),
+            message: format!(
+                "Unexpected rule in interpret_axis_increment: {:?}",
+                inner_pair.as_rule()
+            ),
         });
     }
     let increment = evaluate_expression(inner_pair, state)?;
@@ -874,7 +892,7 @@ fn interpret_axis_increment(pair: Pair<Rule>, state: &mut State, key: String) ->
         Some(local_coord) => {
             // Add increment to current local coordinate
             Ok(local_coord + increment)
-        },
+        }
         None => {
             crate::state::emit_warning(format_args!(
                 "Warning: axis '{}' is incremented with IC() before any absolute position was set; assuming it starts at 0 (a real control would start from the actual axis position).",
@@ -886,7 +904,10 @@ fn interpret_axis_increment(pair: Pair<Rule>, state: &mut State, key: String) ->
 }
 /// Returns each target key with the value assigned to it, or `None` for
 /// keys a gap in the value array left untouched.
-fn interpret_assignment_multi(element: Pair<Rule>, state: &mut State) -> Result<Vec<(String, Option<f64>)>, ParsingError> {
+fn interpret_assignment_multi(
+    element: Pair<Rule>,
+    state: &mut State,
+) -> Result<Vec<(String, Option<f64>)>, ParsingError> {
     // assignment_multi =  { variable_array ~ "=" ~ (value_array | value_repeating) }
     let mut inner_pairs = element.into_inner();
     let variable_pair = inner_pairs
@@ -942,9 +963,14 @@ fn interpret_value_array(pair: Pair<Rule>, state: &mut State) -> Result<Vec<Opti
     Ok(values)
 }
 fn interpret_variable(pair: Pair<Rule>, state: &State) -> Result<String, ParsingError> {
-    let inner = pair.clone().into_inner().next()
-        .ok_or_else(|| annotate_error(&pair, "variable parsing", 
-            "Expected inner pair, found none".to_string(), state))?;
+    let inner = pair.clone().into_inner().next().ok_or_else(|| {
+        annotate_error(
+            &pair,
+            "variable parsing",
+            "Expected inner pair, found none".to_string(),
+            state,
+        )
+    })?;
     match inner.as_rule() {
         // A plain user variable, or a `$`-prefixed system variable such as
         // `$AC_TIMER`. There is no system-variable model, so system variables
@@ -952,8 +978,12 @@ fn interpret_variable(pair: Pair<Rule>, state: &State) -> Result<String, Parsing
         // Uppercased: the language is case-insensitive (manual 3.3.2), so
         // `lAYER_HEIGHT` and `LAYER_HEIGHT` are the same variable.
         Rule::identifier | Rule::nc_variable => Ok(inner.as_str().to_uppercase()),
-        _ => Err(annotate_error(&pair, "variable parsing",
-            format!("Expected identifier, found '{:?}'", inner.as_rule()), state)),
+        _ => Err(annotate_error(
+            &pair,
+            "variable parsing",
+            format!("Expected identifier, found '{:?}'", inner.as_rule()),
+            state,
+        )),
     }
 }
 fn interpret_variable_array(inner: Pair<Rule>, state: &mut State) -> Result<Vec<String>, ParsingError> {
@@ -1068,13 +1098,13 @@ fn interpret_indices(pair: Pair<Rule>, state: &mut State) -> Result<Vec<f64>, Pa
     let mut indices = Vec::new();
     // Get error context before consuming pair
     let (pair_line_no, pair_preview) = get_error_context(&pair, state);
-    
+
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::expression => {
                 // Try to resolve axis identifier to index if possible
                 let expr_str = inner.as_str().trim().to_string();
-                
+
                 if state.is_axis(&expr_str) {
                     let (line_no, preview) = get_error_context(&inner, state);
                     let index = state.get_axis_index(&expr_str, line_no, &preview)?;
@@ -1110,7 +1140,7 @@ fn interpret_indices(pair: Pair<Rule>, state: &mut State) -> Result<Vec<f64>, Pa
 fn interpret_identifier(pair: Pair<Rule>) -> Result<String, ParsingError> {
     let line_no = pair.line_col().0;
     let preview = pair.as_str().to_string();
-    
+
     // Accept both plain identifiers and `$`-prefixed system variables (e.g.
     // `$AC_TIMER[1]`); the latter are stored by their full name like ordinary
     // variables, since there is no dedicated system-variable model.
@@ -1160,7 +1190,10 @@ fn interpret_definition(element: Pair<Rule>, output: &mut Output, state: &mut St
                                 line_no,
                                 preview,
                                 "interpret_definition".to_string(),
-                                format!("numeric variable '{}' initialized with a string (declare it DEF STRING[n])", res.0),
+                                format!(
+                                    "numeric variable '{}' initialized with a string (declare it DEF STRING[n])",
+                                    res.0
+                                ),
                             ));
                         }
                     }
@@ -1260,10 +1293,9 @@ fn interpret_statement_if(
     let mut pairs = element.into_inner();
 
     // Match the condition
-    let condition = pairs.next().ok_or_else(|| ParsingError::InvalidElementCount {
-        expected: 1,
-        actual: 0,
-    })?;
+    let condition = pairs
+        .next()
+        .ok_or_else(|| ParsingError::InvalidElementCount { expected: 1, actual: 0 })?;
     if condition.as_rule() != Rule::condition {
         return Err(ParsingError::UnexpectedRule {
             rule: condition.as_rule(),
@@ -1283,10 +1315,9 @@ fn interpret_statement_if(
     }
 
     // Match the true block
-    let true_block = pairs.next().ok_or_else(|| ParsingError::InvalidElementCount {
-        expected: 1,
-        actual: 0,
-    })?;
+    let true_block = pairs
+        .next()
+        .ok_or_else(|| ParsingError::InvalidElementCount { expected: 1, actual: 0 })?;
     if true_block.as_rule() != Rule::blocks {
         return Err(ParsingError::UnexpectedRule {
             rule: true_block.as_rule(),
@@ -1316,10 +1347,7 @@ fn interpret_statement_if(
 
     // Ensure no extra rules are present
     if pairs.next().is_some() {
-        return Err(ParsingError::InvalidElementCount {
-            expected: 3,
-            actual: 4,
-        });
+        return Err(ParsingError::InvalidElementCount { expected: 3, actual: 4 });
     }
 
     // Handle the comment
@@ -1469,7 +1497,10 @@ fn interpret_statement_repeat_until(
                         context: "interpret_statement_repeat_until".to_string(),
                         line_no: first_pair.line_col().0,
                         preview: state.get_line(first_pair.line_col().0).unwrap_or("").to_string(),
-                        message: format!("Unexpected rule in interpret_statement_repeat_until: {:?}", first_pair.as_rule()),
+                        message: format!(
+                            "Unexpected rule in interpret_statement_repeat_until: {:?}",
+                            first_pair.as_rule()
+                        ),
                     });
                 }
             }
@@ -1483,7 +1514,10 @@ fn interpret_statement_repeat_until(
                 context: "interpret_statement_repeat_until".to_string(),
                 line_no: first_pair.line_col().0,
                 preview: state.get_line(first_pair.line_col().0).unwrap_or("").to_string(),
-                message: format!("Unexpected rule in interpret_statement_repeat_until: {:?}", first_pair.as_rule()),
+                message: format!(
+                    "Unexpected rule in interpret_statement_repeat_until: {:?}",
+                    first_pair.as_rule()
+                ),
             });
         }
     }
@@ -1610,11 +1644,7 @@ fn interpret_case(pair: Pair<Rule>, state: &mut State) -> Result<BlockFlow, Pars
     Ok(BlockFlow::Continue)
 }
 
-fn interpret_control(
-    element: Pair<Rule>,
-    output: &mut Output,
-    state: &mut State,
-) -> Result<BlockFlow, ParsingError> {
+fn interpret_control(element: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
     // A control element is a single statement, except for conditional jumps
     // where several may share one block; the first satisfied jump wins.
     for pair in element.into_inner() {
@@ -1657,7 +1687,12 @@ fn interpret_control(
     }
     Ok(BlockFlow::Continue)
 }
-pub(crate) fn insert_m_key(last: &mut crate::output::CellMap, value: &str, line_no: usize, preview: String) -> Result<(), ParsingError> {
+pub(crate) fn insert_m_key(
+    last: &mut crate::output::CellMap,
+    value: &str,
+    line_no: usize,
+    preview: String,
+) -> Result<(), ParsingError> {
     let m_key = "M";
     // Uppercase: the language is case-insensitive (m30 IS M30); source case
     // must not leak into the output values.
@@ -1707,11 +1742,7 @@ pub(crate) fn looks_like_axis_word_typo(name: &str) -> bool {
         && chars[2..].iter().any(|c| c.is_ascii_alphabetic())
 }
 
-fn interpret_statement(
-    element: Pair<Rule>,
-    output: &mut Output,
-    state: &mut State,
-) -> Result<BlockFlow, ParsingError> {
+fn interpret_statement(element: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
     // Grammar:
     // statement           =  {
     //     g_command_numbered
@@ -1830,10 +1861,7 @@ fn interpret_statement(
 /// Evaluate the assignments of a frame instruction without moving any axis:
 /// the axis state is saved and restored around parsing, and each assignment
 /// must target a valid axis.
-fn frame_assignments(
-    pairs: Vec<Pair<Rule>>,
-    state: &mut State,
-) -> Result<Vec<(String, f64)>, ParsingError> {
+fn frame_assignments(pairs: Vec<Pair<Rule>>, state: &mut State) -> Result<Vec<(String, f64)>, ParsingError> {
     let mut result = Vec::with_capacity(pairs.len());
     // Save the axis state once for the whole instruction; interpret_assignment
     // mutates it as a side effect and frame instructions must not move axes.
@@ -1935,18 +1963,16 @@ fn interpret_block_number(element: Pair<Rule>, output: &mut Output) {
 }
 fn get_error_context(pair: &Pair<Rule>, state: &State) -> (usize, String) {
     let (line_no, _) = pair.line_col();
-    let preview = state.get_line(line_no).unwrap_or("(could not retrieve line)").to_string();
+    let preview = state
+        .get_line(line_no)
+        .unwrap_or("(could not retrieve line)")
+        .to_string();
     (line_no, preview)
 }
 
 fn annotate_error(pair: &Pair<Rule>, context: &str, message: String, state: &State) -> ParsingError {
     let (line_no, preview) = get_error_context(pair, state);
-    ParsingError::with_context(
-        line_no,
-        preview,
-        context.to_string(),
-        message,
-    )
+    ParsingError::with_context(line_no, preview, context.to_string(), message)
 }
 
 pub(crate) fn interpret_block(
@@ -1977,28 +2003,38 @@ pub(crate) fn interpret_block(
                     Rule::comment => {
                         let last = output.last_mut().expect("Output vector should not be empty");
                         last.insert("comment", Value::Str(item.as_str().to_string()));
-                    },
-                    _ => return Err(annotate_error(&item, "block interpretation",
-                        format!("Unexpected rule: {:?}", item.as_rule()), state)),
+                    }
+                    _ => {
+                        return Err(annotate_error(
+                            &item,
+                            "block interpretation",
+                            format!("Unexpected rule: {:?}", item.as_rule()),
+                            state,
+                        ))
+                    }
                 }
             }
             Ok(flow)
         }
         _ => {
-            return Err(annotate_error(&element, "blocks interpretation",
-                format!("Expected blocks, found {:?}", element.as_rule()), state));
+            return Err(annotate_error(
+                &element,
+                "blocks interpretation",
+                format!("Expected blocks, found {:?}", element.as_rule()),
+                state,
+            ));
         }
     }
 }
 
-pub fn interpret_blocks(
-    blocks: Pair<Rule>,
-    output: &mut Output,
-    state: &mut State,
-) -> Result<BlockFlow, ParsingError> {
+pub fn interpret_blocks(blocks: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
     if blocks.as_rule() != Rule::blocks {
-        return Err(annotate_error(&blocks, "blocks interpretation",
-            format!("Expected blocks, found {:?}", blocks.as_rule()), state));
+        return Err(annotate_error(
+            &blocks,
+            "blocks interpretation",
+            format!("Expected blocks, found {:?}", blocks.as_rule()),
+            state,
+        ));
     }
     let block_pairs: Vec<Pair<Rule>> = blocks.into_inner().collect();
     let targets = scan_jump_targets(&block_pairs);
@@ -2066,7 +2102,10 @@ mod arity_tests {
         // SIN expects 1 argument; feeding it 2 must not index out of bounds.
         let err = run("X=SIN(30, 45)\nM30\n").expect_err("wrong arity must error");
         assert!(err.contains("SIN"), "error should name the offending function: {err}");
-        assert!(err.contains("expects 1 argument"), "error should state the expected arity: {err}");
+        assert!(
+            err.contains("expects 1 argument"),
+            "error should state the expected arity: {err}"
+        );
     }
 
     #[test]
@@ -2081,7 +2120,10 @@ mod arity_tests {
         // ATAN2 expects 2 arguments; feeding it 1 must not index out of bounds.
         let err = run("X=ATAN2(30)\nM30\n").expect_err("wrong arity must error");
         assert!(err.contains("ATAN2"), "error should name the offending function: {err}");
-        assert!(err.contains("expects 2 argument"), "error should state the expected arity: {err}");
+        assert!(
+            err.contains("expects 2 argument"),
+            "error should state the expected arity: {err}"
+        );
     }
 
     #[test]
@@ -2089,7 +2131,10 @@ mod arity_tests {
         // BOUND expects 3 arguments; feeding it 2 must not index out of bounds.
         let err = run("X=BOUND(0, 10)\nM30\n").expect_err("wrong arity must error");
         assert!(err.contains("BOUND"), "error should name the offending function: {err}");
-        assert!(err.contains("expects 3 argument"), "error should state the expected arity: {err}");
+        assert!(
+            err.contains("expects 3 argument"),
+            "error should state the expected arity: {err}"
+        );
     }
 
     #[test]
@@ -2099,4 +2144,3 @@ mod arity_tests {
         run("X=BOUND(0, 10, 5)\nM30\n").expect("correct arity must not error");
     }
 }
-

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -61,7 +61,12 @@ fn build_state(
     if let Some(extra_axes) = extra_axes {
         axis_identifiers.extend(extra_axes);
     }
-    state::State::new(axis_identifiers, iteration_limit, axis_index_map, allow_undefined_variables)
+    state::State::new(
+        axis_identifiers,
+        iteration_limit,
+        axis_index_map,
+        allow_undefined_variables,
+    )
 }
 
 /// Install the curve flattener on the output when a tolerance was given
@@ -198,8 +203,7 @@ pub fn nc_to_batch_stream_with_line_numbers(
         let mut discard = OutputRows::collect();
         interpret_file(initial_state, &mut state, &mut discard)?;
     }
-    let mut output =
-        OutputRows::batch_stream_with_line_numbers(sender, batch_size, disable_forward_fill, emit_line_no);
+    let mut output = OutputRows::batch_stream_with_line_numbers(sender, batch_size, disable_forward_fill, emit_line_no);
     install_flattener(&mut output, &state, flatten_tolerance)?;
     interpret_file(input, &mut state, &mut output)?;
     output.finish()?;
@@ -249,12 +253,9 @@ fn interpret_file(input: &str, state: &mut State, output: &mut OutputRows) -> Re
             message: "No blocks found".to_string(),
         })?;
 
-    let blocks = file
-        .into_inner()
-        .next()
-        .ok_or_else(|| ParsingError::ParseError {
-            message: "No inner blocks found".to_string(),
-        })?;
+    let blocks = file.into_inner().next().ok_or_else(|| ParsingError::ParseError {
+        message: "No inner blocks found".to_string(),
+    })?;
 
     match interpret_blocks(blocks, output, state)? {
         BlockFlow::Continue | BlockFlow::EndProgram => Ok(()),
@@ -330,10 +331,19 @@ fn describe_rule(rule: Rule) -> &'static str {
         Rule::frame_op | Rule::frame_kw => "a frame instruction (TRANS/ROT/...)",
         Rule::m_command => "an M code",
         Rule::g_command | Rule::g_command_numbered => "a G code",
-        Rule::op_add | Rule::op_sub | Rule::op_mul | Rule::op_div | Rule::op_int_div | Rule::op_mod | Rule::neg
-        | Rule::op_and | Rule::op_or | Rule::op_xor | Rule::op_b_and | Rule::op_b_or | Rule::op_b_xor => {
-            "an operator"
-        }
+        Rule::op_add
+        | Rule::op_sub
+        | Rule::op_mul
+        | Rule::op_div
+        | Rule::op_int_div
+        | Rule::op_mod
+        | Rule::neg
+        | Rule::op_and
+        | Rule::op_or
+        | Rule::op_xor
+        | Rule::op_b_and
+        | Rule::op_b_or
+        | Rule::op_b_xor => "an operator",
         Rule::value_array | Rule::value_repeating | Rule::value_none => "SET/REP values",
         Rule::WHITESPACE => "whitespace",
         // Everything not listed is one of the generated G-group rules.
@@ -355,7 +365,10 @@ mod parse_speed {
     struct Lcg(u64);
     impl Lcg {
         fn next(&mut self) -> u64 {
-            self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             self.0 >> 33
         }
         fn coord(&mut self) -> f64 {
@@ -436,7 +449,12 @@ mod parse_speed {
         if let Ok(path) = std::env::var("BENCH_FILE") {
             let input = std::fs::read_to_string(&path).expect("BENCH_FILE must be readable");
             let lines = input.lines().count();
-            println!("input: {} ({} lines, {:.1} MB)", path, lines, input.len() as f64 / 1_048_576.0);
+            println!(
+                "input: {} ({} lines, {:.1} MB)",
+                path,
+                lines,
+                input.len() as f64 / 1_048_576.0
+            );
             let start = Instant::now();
             let pairs = NCParser::parse(Rule::file, &input).expect("BENCH_FILE must parse");
             let parse_time = start.elapsed();
@@ -480,11 +498,7 @@ mod parse_speed {
             Ok("bspline") => "BSPLINE\n".repeat(lines),
             _ => generate_flood(lines),
         };
-        println!(
-            "input: {} lines, {:.1} MB",
-            lines,
-            input.len() as f64 / 1_048_576.0
-        );
+        println!("input: {} lines, {:.1} MB", lines, input.len() as f64 / 1_048_576.0);
 
         let start = Instant::now();
         let pairs = NCParser::parse(Rule::file, &input).expect("benchmark input must parse");
@@ -498,11 +512,7 @@ mod parse_speed {
 
         let start = Instant::now();
         let token_count = pairs.flatten().count();
-        println!(
-            "tree iteration:  {:>8.2?}  ({} pairs)",
-            start.elapsed(),
-            token_count
-        );
+        println!("tree iteration:  {:>8.2?}  ({} pairs)", start.elapsed(), token_count);
 
         let start = Instant::now();
         let (table, _state) =
@@ -530,7 +540,12 @@ mod interpret_speed {
         let path = std::env::var("BENCH_FILE").expect("set BENCH_FILE");
         let input = std::fs::read_to_string(&path).expect("readable");
         let lines = input.lines().count();
-        println!("input: {} ({} lines, {:.1} MB)", path, lines, input.len() as f64 / 1_048_576.0);
+        println!(
+            "input: {} ({} lines, {:.1} MB)",
+            path,
+            lines,
+            input.len() as f64 / 1_048_576.0
+        );
         let extra = Some(vec!["ELX".to_string()]);
         let aim = Some(HashMap::from([("E".to_string(), 4usize), ("ELX".to_string(), 5usize)]));
 
@@ -541,7 +556,11 @@ mod interpret_speed {
         interpret_file(&input, &mut state, &mut output).expect("interpret");
         let rows = output.finish().expect("finish");
         let materialize = start.elapsed();
-        println!("interpret+materialize (collect): {:>8.2?}  ({} rows)", materialize, rows.len());
+        println!(
+            "interpret+materialize (collect): {:>8.2?}  ({} rows)",
+            materialize,
+            rows.len()
+        );
 
         let start = Instant::now();
         let _table = Table::from_rows(&rows, false);
@@ -555,8 +574,8 @@ mod tests {
     use crate::output::Column;
 
     fn interpret(input: &str) -> Table {
-        let (table, _state) = nc_to_table(input, None, None, None, 10000, false, None, false, None)
-            .expect("program should interpret");
+        let (table, _state) =
+            nc_to_table(input, None, None, None, 10000, false, None, false, None).expect("program should interpret");
         table
     }
 
@@ -600,8 +619,7 @@ mod tests {
 
         // WHILE loop: the body (line 3) repeats; line 4 assigns a plain
         // variable and emits no output row; line 6 follows the loop.
-        let table =
-            interpret_with_line_numbers("R1=0\nWHILE R1<2\nX=R1\nR1=R1+1\nENDWHILE\nX9\n");
+        let table = interpret_with_line_numbers("R1=0\nWHILE R1<2\nX=R1\nR1=R1+1\nENDWHILE\nX9\n");
         assert_eq!(ints(&table, "line_no"), &[Some(3), Some(3), Some(6)]);
 
         // GOTO reorders execution: only the source lines that ran appear, in
@@ -633,17 +651,22 @@ mod tests {
     #[test]
     fn actual_position_sysvars_read_axis_state() {
         let run = |src: &str| {
-            nc_to_table(src, None, None, None, 10000, false, None, false, None)
-                .expect("program should interpret")
+            nc_to_table(src, None, None, None, 10000, false, None, false, None).expect("program should interpret")
         };
         // Layer loop: Z climbs 1 mm per pass until above 4.5.
-        let (table, state) = run(
-            "G1 X0 Y0 Z0 F100\nREPEAT\nZ=IC(1)\nUNTIL $AA_IW[Z] > 4.5\nM30\n",
-        );
+        let (table, state) = run("G1 X0 Y0 Z0 F100\nREPEAT\nZ=IC(1)\nUNTIL $AA_IW[Z] > 4.5\nM30\n");
         assert_eq!(state.axes["Z"], 5.0);
         assert_eq!(
             floats(&table, "Z"),
-            &[Some(0.0), Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0), Some(5.0)]
+            &[
+                Some(0.0),
+                Some(1.0),
+                Some(2.0),
+                Some(3.0),
+                Some(4.0),
+                Some(5.0),
+                Some(5.0)
+            ]
         );
         // IW is the work coordinate, IM includes the active translation.
         let (_, state) = run("TRANS Z10\nG1 Z5 F100\nR1 = $AA_IW[Z]\nR2 = $AA_IM[Z]\nM30\n");
@@ -662,13 +685,33 @@ mod tests {
         let (_, state) = nc_to_table("R1 = $AA_IW[Z]\n", None, None, None, 10000, false, None, true, None)
             .expect("allow_undefined_variables tolerates the early read");
         assert_eq!(state.symbol_table["R1"], 0.0);
-        let err = nc_to_table("G1 Z0 F100\n$AA_IW[Z] = 5\n", None, None, None, 10000, false, None, false, None)
-            .unwrap_err();
+        let err = nc_to_table(
+            "G1 Z0 F100\n$AA_IW[Z] = 5\n",
+            None,
+            None,
+            None,
+            10000,
+            false,
+            None,
+            false,
+            None,
+        )
+        .unwrap_err();
         assert!(format!("{err}").contains("read-only"), "got: {err}");
         // The guard is structural, not textual: whitespace inside the
         // subscript must not sneak the assignment past it.
-        let err = nc_to_table("G1 Z0 F100\n$AA_IW[ Z ] = 5\n", None, None, None, 10000, false, None, false, None)
-            .unwrap_err();
+        let err = nc_to_table(
+            "G1 Z0 F100\n$AA_IW[ Z ] = 5\n",
+            None,
+            None,
+            None,
+            10000,
+            false,
+            None,
+            false,
+            None,
+        )
+        .unwrap_err();
         assert!(format!("{err}").contains("read-only"), "got: {err}");
     }
 
@@ -685,14 +728,24 @@ mod tests {
         // The guarded G1 X10 ran iff an X column exists in the output.
         let branch_ran = |src: &str| run(src).columns.iter().any(|(n, _)| n == "X");
         // Parenthesized comparisons joined by AND - both true and one false.
-        assert!(branch_ran("R1=1 R2=1\nIF ((R1 == 1) AND (R2 == 1))\nG1 X10 F100\nENDIF\nM30\n"));
-        assert!(!branch_ran("R1=1 R2=0\nIF ((R1 == 1) AND (R2 == 1))\nG1 X10 F100\nENDIF\nM30\n"));
+        assert!(branch_ran(
+            "R1=1 R2=1\nIF ((R1 == 1) AND (R2 == 1))\nG1 X10 F100\nENDIF\nM30\n"
+        ));
+        assert!(!branch_ran(
+            "R1=1 R2=0\nIF ((R1 == 1) AND (R2 == 1))\nG1 X10 F100\nENDIF\nM30\n"
+        ));
         // OR and NOT.
-        assert!(branch_ran("R1=0 R2=1\nIF ((R1 == 1) OR (R2 == 1))\nG1 X10 F100\nENDIF\nM30\n"));
+        assert!(branch_ran(
+            "R1=0 R2=1\nIF ((R1 == 1) OR (R2 == 1))\nG1 X10 F100\nENDIF\nM30\n"
+        ));
         assert!(branch_ran("R1=0\nIF NOT R1\nG1 X10 F100\nENDIF\nM30\n"));
         // XOR.
-        assert!(!branch_ran("R1=1 R2=1\nIF ((R1==1) XOR (R2==1))\nG1 X10 F100\nENDIF\nM30\n"));
-        assert!(branch_ran("R1=0 R2=1\nIF ((R1==1) XOR (R2==1))\nG1 X10 F100\nENDIF\nM30\n"));
+        assert!(!branch_ran(
+            "R1=1 R2=1\nIF ((R1==1) XOR (R2==1))\nG1 X10 F100\nENDIF\nM30\n"
+        ));
+        assert!(branch_ran(
+            "R1=0 R2=1\nIF ((R1==1) XOR (R2==1))\nG1 X10 F100\nENDIF\nM30\n"
+        ));
     }
 
     /// The manual's exact priority table (4.1.3.3): AND (7) binds TIGHTER
@@ -702,8 +755,8 @@ mod tests {
     #[test]
     fn operator_priorities_match_the_manual() {
         let value_of_r9 = |src: &str| {
-            let (_, state) = nc_to_table(src, None, None, None, 10000, false, None, false, None)
-                .expect("program should interpret");
+            let (_, state) =
+                nc_to_table(src, None, None, None, 10000, false, None, false, None).expect("program should interpret");
             state.symbol_table["R9"]
         };
         // A=0, B=0: 1 AND 0 = 0; 0 == 0 = TRUE(1); 1 == 1 = TRUE.
@@ -850,10 +903,7 @@ mod tests {
             floats(&table, "J"),
             &[None, Some(0.0), None, Some(0.0), Some(-25.0), None]
         );
-        assert_eq!(
-            floats(&table, "K"),
-            &[None, None, None, None, Some(5.0), None]
-        );
+        assert_eq!(floats(&table, "K"), &[None, None, None, None, Some(5.0), None]);
 
         // Axes are still forward-filled; the arc offsets are not.
         assert_eq!(floats(&table, "X").last().unwrap(), &Some(60.0));
@@ -893,10 +943,7 @@ mod tests {
                 other => panic!("column {name} is not a str column: {other:?}"),
             }
         };
-        assert_eq!(
-            strs("gg01_motion"),
-            &[Some("G1".to_string()), Some("G2".to_string())]
-        );
+        assert_eq!(strs("gg01_motion"), &[Some("G1".to_string()), Some("G2".to_string())]);
         assert_eq!(
             strs("gg06_plane_select"),
             &[Some("G17".to_string()), Some("G17".to_string())]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@ mod errors;
 pub mod flatten;
 mod interpret_rules;
 pub mod interpreter;
+mod line_driver;
 mod modal_groups;
 pub mod output;
-mod line_driver;
 mod state;
 mod structure_scan;
 
@@ -17,9 +17,9 @@ mod structure_scan;
 mod python_bindings {
     use pyo3::exceptions::PyValueError;
     use pyo3::prelude::*;
+    use pyo3::types::PyCapsule;
     use pyo3::types::{PyDict, PyList};
     use pyo3::wrap_pyfunction;
-    use pyo3::types::PyCapsule;
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -51,10 +51,8 @@ mod python_bindings {
             // Capsule names are fixed by the Arrow C data interface; the boxed
             // FFI struct's Drop runs the Arrow release callback when the consumer
             // has not moved it out.
-            let schema_capsule =
-                PyCapsule::new_with_value(py, schema, c"arrow_schema")?;
-            let array_capsule =
-                PyCapsule::new_with_value(py, array, c"arrow_array")?;
+            let schema_capsule = PyCapsule::new_with_value(py, schema, c"arrow_schema")?;
+            let array_capsule = PyCapsule::new_with_value(py, array, c"arrow_array")?;
             Ok((schema_capsule, array_capsule))
         }
     }
@@ -137,12 +135,9 @@ mod python_bindings {
                     Arc::new(v.into_iter().collect::<StringArray>()),
                 ),
                 Column::StrList(v) => {
-                    let values_cap: usize =
-                        v.iter().filter_map(|c| c.as_ref()).map(|l| l.len()).sum();
-                    let mut builder =
-                        ListBuilder::with_capacity(StringBuilder::new(), v.len()).with_field(Arc::new(
-                            Field::new("item", DataType::Utf8, false),
-                        ));
+                    let values_cap: usize = v.iter().filter_map(|c| c.as_ref()).map(|l| l.len()).sum();
+                    let mut builder = ListBuilder::with_capacity(StringBuilder::new(), v.len())
+                        .with_field(Arc::new(Field::new("item", DataType::Utf8, false)));
                     let _ = values_cap;
                     for cell in v {
                         match cell {
@@ -179,7 +174,9 @@ mod python_bindings {
     fn table_to_arrow_batch(table: Table) -> PyResult<ArrowBatch> {
         use arrow_array::Array;
         let struct_array = arrow_array::StructArray::from(table_to_record_batch(table)?);
-        Ok(ArrowBatch { data: struct_array.into_data() })
+        Ok(ArrowBatch {
+            data: struct_array.into_data(),
+        })
     }
 
     /// Spawn the interpreter on a worker thread, pushing finished rows into a
@@ -224,9 +221,7 @@ mod python_bindings {
                 };
                 let _ = result_sender.send(message);
             })
-            .map_err(|e| {
-                PyErr::new::<PyValueError, _>(format!("failed to spawn interpreter thread: {}", e))
-            })?;
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("failed to spawn interpreter thread: {}", e)))?;
         Ok((row_receiver, result_receiver, handle))
     }
 
@@ -283,9 +278,7 @@ mod python_bindings {
                 };
                 let _ = result_sender.send(message);
             })
-            .map_err(|e| {
-                PyErr::new::<PyValueError, _>(format!("failed to spawn interpreter thread: {}", e))
-            })?;
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("failed to spawn interpreter thread: {}", e)))?;
         Ok((batch_receiver, result_receiver, handle))
     }
 
@@ -481,9 +474,8 @@ mod python_bindings {
         // PyO3 boundary. Reading before the worker spawns surfaces a missing
         // file as an immediate, clean error.
         let input = if input_is_path {
-            std::fs::read_to_string(&input).map_err(|e| {
-                PyErr::new::<PyValueError, _>(format!("Error reading input file '{}': {}", input, e))
-            })?
+            std::fs::read_to_string(&input)
+                .map_err(|e| PyErr::new::<PyValueError, _>(format!("Error reading input file '{}': {}", input, e)))?
         } else {
             input
         };
@@ -622,9 +614,8 @@ mod python_bindings {
         }
         // Read the program here when given a path (see nc_to_rows).
         let input = if input_is_path {
-            std::fs::read_to_string(&input).map_err(|e| {
-                PyErr::new::<PyValueError, _>(format!("Error reading input file '{}': {}", input, e))
-            })?
+            std::fs::read_to_string(&input)
+                .map_err(|e| PyErr::new::<PyValueError, _>(format!("Error reading input file '{}': {}", input, e)))?
         } else {
             input
         };

--- a/src/line_driver.rs
+++ b/src/line_driver.rs
@@ -22,8 +22,8 @@
 
 use crate::errors::ParsingError;
 use crate::interpret_rules::{
-    canonical_block_number, insert_m_key, interpret_block,
-    is_end_of_program_m_code, resolve_jump, scan_jump_targets, BlockFlow,
+    canonical_block_number, insert_m_key, interpret_block, is_end_of_program_m_code, resolve_jump, scan_jump_targets,
+    BlockFlow,
 };
 use crate::modal_groups::classify_g_command;
 use crate::state::{ColKind, State};
@@ -195,7 +195,12 @@ pub fn interpret_lines(
         let words: usize = chunk_arenas.iter().map(|a| a.len()).sum();
         eprintln!(
             "STAGE1_STATS non_blank={} needs_grammar={} total_lines={} pass1_decode={:.3}s words={} nchunks={}",
-            non_blank, needs_grammar, lines.len(), t_pass1.elapsed().as_secs_f64(), words, chunk_arenas.len()
+            non_blank,
+            needs_grammar,
+            lines.len(),
+            t_pass1.elapsed().as_secs_f64(),
+            words,
+            chunk_arenas.len()
         );
     }
 
@@ -261,7 +266,10 @@ pub fn interpret_lines(
     state.seen_jump_targets.extend(targets.keys().cloned());
     state.jump_scopes.push(targets.keys().cloned().collect());
     if stats {
-        eprintln!("STAGE1_STATS pass2_setup_done={:.3}s (pass1+pass2, before execution)", t_pass1.elapsed().as_secs_f64());
+        eprintln!(
+            "STAGE1_STATS pass2_setup_done={:.3}s (pass1+pass2, before execution)",
+            t_pass1.elapsed().as_secs_f64()
+        );
     }
     let result = run_lines(&execs, &chunk_arenas, &targets, output, state);
     state.jump_scopes.pop();
@@ -276,10 +284,7 @@ pub fn interpret_lines(
 /// Chunks keep source order (rayon's indexed `par_chunks`/`collect`), so the
 /// flattened result stream is byte-for-byte what the sequential decode
 /// produces. The sequential path is just the single-chunk case.
-fn decode_all_lines<'a>(
-    lines: &[&'a str],
-    input_bytes: usize,
-) -> (Vec<Vec<Word<'a>>>, Vec<Vec<DecodeResult<'a>>>) {
+fn decode_all_lines<'a>(lines: &[&'a str], input_bytes: usize) -> (Vec<Vec<Word<'a>>>, Vec<Vec<DecodeResult<'a>>>) {
     if input_bytes < PARALLEL_MIN_BYTES || rayon::current_num_threads() <= 1 {
         let mut arena: Vec<Word> = Vec::new();
         let mut results: Vec<DecodeResult> = Vec::with_capacity(lines.len());
@@ -324,9 +329,7 @@ fn run_lines(
     while index < execs.len() {
         let flow = match &execs[index] {
             LineExec::Blank => BlockFlow::Continue,
-            LineExec::Decoded(line, chunk_idx) => {
-                execute_decoded(line, &chunk_arenas[*chunk_idx], output, state)?
-            }
+            LineExec::Decoded(line, chunk_idx) => execute_decoded(line, &chunk_arenas[*chunk_idx], output, state)?,
             LineExec::Parsed(block) => interpret_block(block.clone(), output, state)?,
         };
         match flow {
@@ -356,7 +359,12 @@ fn run_lines(
 
 /// Execute a decoded trivial line: the exact effects of `interpret_block`
 /// on the same line, without the parse tree.
-fn execute_decoded(line: &DecodedLine, arena: &[Word], output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
+fn execute_decoded(
+    line: &DecodedLine,
+    arena: &[Word],
+    output: &mut Output,
+    state: &mut State,
+) -> Result<BlockFlow, ParsingError> {
     if !line.has_content {
         return Ok(BlockFlow::Continue);
     }
@@ -389,7 +397,12 @@ fn execute_decoded(line: &DecodedLine, arena: &[Word], output: &mut Output, stat
                     }
                 }
             }
-            Word::AssignDynamic { key, ident, factor, incremental } => {
+            Word::AssignDynamic {
+                key,
+                ident,
+                factor,
+                incremental,
+            } => {
                 // Evaluate `value(ident) * factor` with the exact lookup and
                 // undefined-variable behavior of interpret_primary.
                 let value = match *ident {
@@ -406,7 +419,10 @@ fn execute_decoded(line: &DecodedLine, arena: &[Word], output: &mut Output, stat
                         let ident_value = match state.symbol_table.get(name.as_ref()).copied() {
                             Some(v) => v,
                             None if state.allow_undefined_variables => {
-                                crate::state::emit_warning(format_args!("Warning: Variable '{}' is undefined, initializing to 0.0", name));
+                                crate::state::emit_warning(format_args!(
+                                    "Warning: Variable '{}' is undefined, initializing to 0.0",
+                                    name
+                                ));
                                 state.symbol_table.insert(name.clone().into_owned(), 0.0);
                                 0.0
                             }
@@ -504,13 +520,12 @@ fn execute_decoded(line: &DecodedLine, arena: &[Word], output: &mut Output, stat
     Ok(flow)
 }
 
-fn parse_single_line<'i>(
-    padded: &'i str,
-    line_no: usize,
-    state: &State,
-) -> Result<Pair<'i, Rule>, ParsingError> {
+fn parse_single_line<'i>(padded: &'i str, line_no: usize, state: &State) -> Result<Pair<'i, Rule>, ParsingError> {
     let parsed = NCParser::parse(Rule::line_entry, padded).map_err(|e| {
-        let preview = state.get_line(line_no).unwrap_or("(could not retrieve line)").to_string();
+        let preview = state
+            .get_line(line_no)
+            .unwrap_or("(could not retrieve line)")
+            .to_string();
         let col = match &e.line_col {
             pest::error::LineColLocation::Pos(pos) => pos.1,
             pest::error::LineColLocation::Span(start, _) => start.1,
@@ -571,8 +586,8 @@ fn parse_number(line: &str, i: &mut usize) -> Option<f64> {
 /// a call in the full grammar (the line takes a control-flow rule or fails
 /// to parse), so the fast path must reject it to the grammar.
 const RESERVED_WORDS: &[&str] = &[
-    "IF", "ELSE", "ENDIF", "GOTOB", "GOTOF", "GOTOC", "GOTOS", "GOTO", "CASE", "OF", "DEFAULT",
-    "LOOP", "FOR", "WHILE", "REPEAT", "LABEL", "TO", "UNTIL", "ENDWHILE", "ENDFOR", "ENDLOOP",
+    "IF", "ELSE", "ENDIF", "GOTOB", "GOTOF", "GOTOC", "GOTOS", "GOTO", "CASE", "OF", "DEFAULT", "LOOP", "FOR", "WHILE",
+    "REPEAT", "LABEL", "TO", "UNTIL", "ENDWHILE", "ENDFOR", "ENDLOOP",
 ];
 
 fn is_reserved_word(word: &str) -> bool {
@@ -752,11 +767,7 @@ fn fold_const_expr(line: &str, i: &mut usize) -> Option<f64> {
 /// `ident=IC(<product>)`, `ident=(<product>)`, `M<d>`, a vocabulary-known
 /// bare keyword, a bare parameterless subprogram call and a trailing comment
 /// rejects the line to the full grammar.
-fn decode_line<'a>(
-    line: &'a str,
-    line_no: usize,
-    arena: &mut Vec<Word<'a>>,
-) -> DecodeResult<'a> {
+fn decode_line<'a>(line: &'a str, line_no: usize, arena: &mut Vec<Word<'a>>) -> DecodeResult<'a> {
     // Words are appended to the shared arena as they decode. A line that turns
     // out to need the grammar (or is blank) leaves no trace: roll the arena
     // back to where this line started so only claimed trivial lines contribute.
@@ -862,12 +873,24 @@ fn decode_line_inner<'a>(
                 // variable_single_char set (normalized to the uppercase
                 // column key). Anything else needs the grammar.
                 let key = match letter {
-                    b'X' => "X", b'Y' => "Y", b'Z' => "Z",
-                    b'A' => "A", b'B' => "B", b'C' => "C",
-                    b'U' => "U", b'V' => "V", b'W' => "W",
-                    b'I' => "I", b'J' => "J", b'K' => "K",
-                    b'T' => "T", b'S' => "S", b'F' => "F",
-                    b'D' => "D", b'H' => "H", b'E' => "E",
+                    b'X' => "X",
+                    b'Y' => "Y",
+                    b'Z' => "Z",
+                    b'A' => "A",
+                    b'B' => "B",
+                    b'C' => "C",
+                    b'U' => "U",
+                    b'V' => "V",
+                    b'W' => "W",
+                    b'I' => "I",
+                    b'J' => "J",
+                    b'K' => "K",
+                    b'T' => "T",
+                    b'S' => "S",
+                    b'F' => "F",
+                    b'D' => "D",
+                    b'H' => "H",
+                    b'E' => "E",
                     _ => return DecodeResult::NeedsGrammar,
                 };
                 let Some(value) = parse_number(line, &mut i) else {
@@ -905,14 +928,24 @@ fn decode_line_inner<'a>(
                 if let Some((ident, factor, end)) = decode_ic_word(line, i) {
                     // KEY=IC(...): deferred incremental word.
                     i = end;
-                    arena.push(Word::AssignDynamic { key, ident, factor, incremental: true });
+                    arena.push(Word::AssignDynamic {
+                        key,
+                        ident,
+                        factor,
+                        incremental: true,
+                    });
                 } else if i < n_len && bytes[i] == b'(' {
                     // KEY=(IDENT*NUMBER) etc.: deferred absolute word.
                     let Some((ident, factor, end)) = decode_paren_product(line, i + 1) else {
                         return DecodeResult::NeedsGrammar;
                     };
                     i = end;
-                    arena.push(Word::AssignDynamic { key, ident, factor, incremental: false });
+                    arena.push(Word::AssignDynamic {
+                        key,
+                        ident,
+                        factor,
+                        incremental: false,
+                    });
                 } else {
                     // KEY=<constant expression>: fold literals at decode time
                     // (identical evaluation order, see fold_const_expr).
@@ -992,8 +1025,7 @@ fn decode_line_inner<'a>(
 /// Escape hatch for differential testing and debugging: NC_STAGE1=0
 /// disables the fast path so everything runs through the whole-file parse.
 pub fn stage1_enabled() -> bool {
-    !std::env::var("NC_STAGE1")
-        .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"))
+    !std::env::var("NC_STAGE1").is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"))
 }
 
 /// Differential tests: every program must produce identical output with the
@@ -1011,11 +1043,7 @@ mod tests {
     /// NC_STAGE1 is process-global; serialize every test that flips it.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn run(
-        program: &str,
-        stage1: bool,
-        allow_undefined: bool,
-    ) -> Result<(Table, crate::state::State), ParsingError> {
+    fn run(program: &str, stage1: bool, allow_undefined: bool) -> Result<(Table, crate::state::State), ParsingError> {
         std::env::set_var("NC_STAGE1", if stage1 { "1" } else { "0" });
         let result = nc_to_table(
             program,
@@ -1057,9 +1085,15 @@ mod tests {
                     sorted_columns(&fast_table),
                     "table mismatch for program:\n{program}"
                 );
-                assert_eq!(full_state.symbol_table, fast_state.symbol_table, "symbols for:\n{program}");
+                assert_eq!(
+                    full_state.symbol_table, fast_state.symbol_table,
+                    "symbols for:\n{program}"
+                );
                 assert_eq!(full_state.axes, fast_state.axes, "axes for:\n{program}");
-                assert_eq!(full_state.translation, fast_state.translation, "translation for:\n{program}");
+                assert_eq!(
+                    full_state.translation, fast_state.translation,
+                    "translation for:\n{program}"
+                );
             }
             (Err(full_err), Err(fast_err)) => {
                 // Both error. Interpretation errors (undefined variable,
@@ -1069,12 +1103,12 @@ mod tests {
                 let full_msg = full_err.to_string();
                 let fast_msg = fast_err.to_string();
                 if full_msg.contains("Parse error") || fast_msg.contains("Parse error") {
-                    let line_of = |msg: &str| {
-                        msg.lines()
-                            .find(|l| l.starts_with("Line:"))
-                            .map(str::to_string)
-                    };
-                    assert_eq!(line_of(&full_msg), line_of(&fast_msg), "parse-error line for:\n{program}");
+                    let line_of = |msg: &str| msg.lines().find(|l| l.starts_with("Line:")).map(str::to_string);
+                    assert_eq!(
+                        line_of(&full_msg),
+                        line_of(&fast_msg),
+                        "parse-error line for:\n{program}"
+                    );
                 } else {
                     assert_eq!(full_msg, fast_msg, "error mismatch for program:\n{program}");
                 }
@@ -1205,23 +1239,17 @@ M30
         // must decline (transparently falling back to the whole-file parse)
         // instead of paying a per-line pest parse for most of the program.
         let lines = super::RATIO_SAMPLE_MIN + 100;
-        let program: String =
-            (0..lines).map(|_| "X=SIN(30)\n").collect();
+        let program: String = (0..lines).map(|_| "X=SIN(30)\n").collect();
         let _guard = env_lock();
         let (table, _state) = run(&program, true, false).expect("interpret");
-        let x = table
-            .columns
-            .iter()
-            .find(|(name, _)| name == "X")
-            .expect("X column");
+        let x = table.columns.iter().find(|(name, _)| name == "X").expect("X column");
         assert_eq!(x.1.len(), lines);
         // Confirm the decline: interpret_lines itself must return None.
         let mut state = crate::state::State::new(vec!["X".to_string()], 10_000, None, false);
         state.set_input(&program);
         let mut padded = Vec::new();
         let mut output = crate::output::OutputRows::collect();
-        let declined = super::interpret_lines(&program, &mut padded, &mut output, &mut state)
-            .expect("no error");
+        let declined = super::interpret_lines(&program, &mut padded, &mut output, &mut state).expect("no error");
         assert!(declined.is_none(), "expected the ratio guard to decline");
     }
 
@@ -1236,17 +1264,11 @@ M30
                 program.push_str("X1.5 Y2.5\n");
             }
         }
-        let mut state = crate::state::State::new(
-            vec!["X".to_string(), "Y".to_string()],
-            10_000,
-            None,
-            false,
-        );
+        let mut state = crate::state::State::new(vec!["X".to_string(), "Y".to_string()], 10_000, None, false);
         state.set_input(&program);
         let mut padded = Vec::new();
         let mut output = crate::output::OutputRows::collect();
-        let claimed = super::interpret_lines(&program, &mut padded, &mut output, &mut state)
-            .expect("no error");
+        let claimed = super::interpret_lines(&program, &mut padded, &mut output, &mut state).expect("no error");
         assert!(claimed.is_some(), "expected the fast path to claim the program");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ mod errors;
 mod flatten;
 mod interpret_rules;
 mod interpreter;
-mod modal_groups;
 mod line_driver;
+mod modal_groups;
+mod output;
 mod state;
 mod structure_scan;
-mod output;
 mod types;
 
 use interpreter::nc_to_table;
@@ -113,18 +113,16 @@ fn main() -> io::Result<()> {
         .map(|s| s.split(',').map(|axis| axis.trim().to_string()).collect());
 
     // Parse axis_index_map argument if provided
-    let axis_index_map: Option<HashMap<String, usize>> = matches
-        .get_one::<String>("axis_index_map")
-        .map(|s| {
-            s.split(',')
-                .filter_map(|pair| {
-                    let mut parts = pair.split(':');
-                    let key = parts.next()?.trim().to_string();
-                    let value = parts.next()?.trim().parse::<usize>().ok()?;
-                    Some((key, value))
-                })
-                .collect::<HashMap<_, _>>()
-        });
+    let axis_index_map: Option<HashMap<String, usize>> = matches.get_one::<String>("axis_index_map").map(|s| {
+        s.split(',')
+            .filter_map(|pair| {
+                let mut parts = pair.split(':');
+                let key = parts.next()?.trim().to_string();
+                let value = parts.next()?.trim().parse::<usize>().ok()?;
+                Some((key, value))
+            })
+            .collect::<HashMap<_, _>>()
+    });
 
     let iteration_limit = matches.get_one::<usize>("iteration_limit").unwrap();
 
@@ -132,18 +130,13 @@ fn main() -> io::Result<()> {
 
     let input = std::fs::read_to_string(matches.get_one::<String>("input").unwrap())
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Error reading input file: {}", e)))?;
-        
+
     let initial_state = matches
         .get_one::<String>("initial_state")
         .map(std::fs::read_to_string)
         .transpose()
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Error reading initial state file: {}", e),
-            )
-        })?;
-        
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Error reading initial state file: {}", e)))?;
+
     let allow_undefined_variables = matches.get_flag("allow_undefined_variables");
     let flatten_tolerance = matches.get_one::<f64>("flatten_tolerance").copied();
 
@@ -154,7 +147,7 @@ fn main() -> io::Result<()> {
         extra_axes,
         *iteration_limit,
         disable_forward_fill,
-        axis_index_map, 
+        axis_index_map,
         allow_undefined_variables,
         flatten_tolerance,
     ) {

--- a/src/modal_groups.rs
+++ b/src/modal_groups.rs
@@ -6,27 +6,40 @@
 /// is not a known G command.
 pub fn classify_g_command(word: &str) -> Option<(&'static str, bool)> {
     Some(match word {
-        "G0" | "G1" | "G2" | "G3" | "CIP" | "ASPLINE" | "BSPLINE" | "CSPLINE" | "POLY" | "G33" | "G331" | "G332" | "OEMIPO1" | "OEMIPO2" | "CT" | "G34" | "G35" | "INVCW" | "INVCCW" | "G335" | "G336" => ("gg01_motion", true),
-        "G4" | "G63" | "G74" | "G75" | "REPOSL" | "REPOSQ" | "REPOSH" | "REPOSA" | "REPOSQA" | "REPOSHA" | "G147" | "G247" | "G347" | "G148" | "G248" | "G348" | "G5" | "G7" => ("gg02_wait", false),
-        "TRANS" | "ROT" | "SCALE" | "MIRROR" | "ATRANS" | "AROT" | "ASCALE" | "AMIRROR" | "G25" | "G26" | "G110" | "G111" | "G112" | "G58" | "G59" | "ROTS" | "AROTS" => ("gg03_frame_area_limit", false),
+        "G0" | "G1" | "G2" | "G3" | "CIP" | "ASPLINE" | "BSPLINE" | "CSPLINE" | "POLY" | "G33" | "G331" | "G332"
+        | "OEMIPO1" | "OEMIPO2" | "CT" | "G34" | "G35" | "INVCW" | "INVCCW" | "G335" | "G336" => ("gg01_motion", true),
+        "G4" | "G63" | "G74" | "G75" | "REPOSL" | "REPOSQ" | "REPOSH" | "REPOSA" | "REPOSQA" | "REPOSHA" | "G147"
+        | "G247" | "G347" | "G148" | "G248" | "G348" | "G5" | "G7" => ("gg02_wait", false),
+        "TRANS" | "ROT" | "SCALE" | "MIRROR" | "ATRANS" | "AROT" | "ASCALE" | "AMIRROR" | "G25" | "G26" | "G110"
+        | "G111" | "G112" | "G58" | "G59" | "ROTS" | "AROTS" => ("gg03_frame_area_limit", false),
         "STARTFIFO" | "STOPFIFO" | "FIFOCTRL" => ("gg04_fifo", true),
         "G17" | "G18" | "G19" => ("gg06_plane_select", true),
         "G40" | "G41" | "G42" => ("gg07_tool_radius", true),
-        "G500" | "G54" | "G55" | "G56" | "G57" | "G505" | "G506" | "G507" | "G508" | "G509" | "G510" | "G511" | "G512" | "G513" | "G514" | "G515" | "G516" | "G517" | "G518" | "G519" | "G520" | "G521" | "G522" | "G523" | "G524" | "G525" | "G526" | "G527" | "G528" | "G529" | "G530" | "G531" | "G532" | "G533" | "G534" | "G535" | "G536" | "G537" | "G538" | "G539" | "G540" | "G541" | "G542" | "G543" | "G544" | "G545" | "G546" | "G547" | "G548" | "G549" | "G550" | "G551" | "G552" | "G553" | "G554" | "G555" | "G556" | "G557" | "G558" | "G559" | "G560" | "G561" | "G562" | "G563" | "G564" | "G565" | "G566" | "G567" | "G568" | "G569" | "G570" | "G571" | "G572" | "G573" | "G574" | "G575" | "G576" | "G577" | "G578" | "G579" | "G580" | "G581" | "G582" | "G583" | "G584" | "G585" | "G586" | "G587" | "G588" | "G589" | "G590" | "G591" | "G592" | "G593" | "G594" | "G595" | "G596" | "G597" | "G598" | "G599" => ("gg08_work_offset", true),
+        "G500" | "G54" | "G55" | "G56" | "G57" | "G505" | "G506" | "G507" | "G508" | "G509" | "G510" | "G511"
+        | "G512" | "G513" | "G514" | "G515" | "G516" | "G517" | "G518" | "G519" | "G520" | "G521" | "G522" | "G523"
+        | "G524" | "G525" | "G526" | "G527" | "G528" | "G529" | "G530" | "G531" | "G532" | "G533" | "G534" | "G535"
+        | "G536" | "G537" | "G538" | "G539" | "G540" | "G541" | "G542" | "G543" | "G544" | "G545" | "G546" | "G547"
+        | "G548" | "G549" | "G550" | "G551" | "G552" | "G553" | "G554" | "G555" | "G556" | "G557" | "G558" | "G559"
+        | "G560" | "G561" | "G562" | "G563" | "G564" | "G565" | "G566" | "G567" | "G568" | "G569" | "G570" | "G571"
+        | "G572" | "G573" | "G574" | "G575" | "G576" | "G577" | "G578" | "G579" | "G580" | "G581" | "G582" | "G583"
+        | "G584" | "G585" | "G586" | "G587" | "G588" | "G589" | "G590" | "G591" | "G592" | "G593" | "G594" | "G595"
+        | "G596" | "G597" | "G598" | "G599" => ("gg08_work_offset", true),
         "G53" | "SUPA" | "G153" | "SUPD" => ("gg09_frame_tool_suppress", false),
         "G60" | "G64" | "G641" | "G642" | "G643" | "G644" | "G645" => ("gg10_exact_stop_mode", true),
         "G9" => ("gg11_exact_stop_non_modal", false),
         "G601" | "G602" | "G603" => ("gg12_block_change_g60_g9", true),
         "G70" | "G71" | "G700" | "G710" => ("gg13_wp_measure", true),
         "G90" | "G91" => ("gg14_wp_measure_mode", true),
-        "G93" | "G94" | "G95" | "G96" | "G97" | "G931" | "G961" | "G971" | "G942" | "G952" | "G962" | "G972" | "G973" => ("gg15_feed_type", true),
+        "G93" | "G94" | "G95" | "G96" | "G97" | "G931" | "G961" | "G971" | "G942" | "G952" | "G962" | "G972"
+        | "G973" => ("gg15_feed_type", true),
         "CFC" | "CFTCP" | "CFIN" => ("gg16_feedrate_override", true),
         "NORM" | "KONT" | "KONTT" | "KONTC" => ("gg17_approach_retract_tool", true),
         "G450" | "G451" => ("gg18_corner_behavior", true),
         "BNAT" | "BTAN" | "BAUTO" => ("gg19_curve_start_spline", true),
         "ENAT" | "ETAN" | "EAUTO" => ("gg20_curve_end_spline", true),
         "BRISK" | "SOFT" | "DRIVE" => ("gg21_accel_profile", true),
-        "CUT2D" | "CUT2DF" | "CUT3DC" | "CUT3DF" | "CUT3DFS" | "CUT3DFF" | "CUT3DCC" | "CUT3DCCD" | "CUT2DD" | "CUT2DFD" | "CUT3DCD" | "CUT3DFD" => ("gg22_tool_offset_type", true),
+        "CUT2D" | "CUT2DF" | "CUT3DC" | "CUT3DF" | "CUT3DFS" | "CUT3DFF" | "CUT3DCC" | "CUT3DCCD" | "CUT2DD"
+        | "CUT2DFD" | "CUT3DCD" | "CUT3DFD" => ("gg22_tool_offset_type", true),
         "CDOF" | "CDON" | "CDOF2" => ("gg23_collision_monitor", true),
         "FFWOF" | "FFWON" => ("gg24_precontrol", true),
         "ORIWKS" | "ORIMKS" => ("gg25_tool_orient_ref", true),
@@ -54,18 +67,36 @@ pub fn classify_g_command(word: &str) -> Option<(&'static str, bool)> {
         "G460" | "G461" | "G462" => ("gg48_approach_retract_trc", true),
         "CP" | "PTP" | "PTPG0" | "PTPWOC" => ("gg49_ptp_motion", true),
         "ORIEULER" | "ORIRPY" | "ORIVIRT1" | "ORIVIRT2" | "ORIAXPOS" | "ORIRPY2" => ("gg50_orient_prog", true),
-        "ORIVECT" | "ORIAXES" | "ORIPATH" | "ORIPLANE" | "ORICONCW" | "ORICONCCW" | "ORICONIO" | "ORICONTO" | "ORICURVE" | "ORIPATHS" => ("gg51_interp_type_orient", true),
+        "ORIVECT" | "ORIAXES" | "ORIPATH" | "ORIPLANE" | "ORICONCW" | "ORICONCCW" | "ORICONIO" | "ORICONTO"
+        | "ORICURVE" | "ORIPATHS" => ("gg51_interp_type_orient", true),
         "PAROTOF" | "PAROT" => ("gg52_frame_rot_wp", true),
         "TOWSTD" | "TOWMCS" | "TOWWCS" | "TOWBCS" | "TOWTCS" | "TOWKCS" => ("gg53_tool_wear", true),
         "ORIROTA" | "ORIROTR" | "ORIROTT" | "ORIROTC" => ("gg54_vector_rot_poly", true),
         "RTLION" | "RTLIOF" => ("gg55_rapid_traverse", true),
-        "TOROTOF" | "TOROT" | "TOROTZ" | "TOROTY" | "TOROTX" | "TOFRAME" | "TOFRAMEZ" | "TOFRAMEY" | "TOFRAMEX" => ("gg56_frame_rot_tool", true),
+        "TOROTOF" | "TOROT" | "TOROTZ" | "TOROTY" | "TOROTX" | "TOFRAME" | "TOFRAMEZ" | "TOFRAMEY" | "TOFRAMEX" => {
+            ("gg56_frame_rot_tool", true)
+        }
         "FENDNORM" | "G62" | "G621" => ("gg57_corner_decel", true),
         "DYNNORM" | "DYNPOS" | "DYNROUGH" | "DYNSEMIFIN" | "DYNFINISH" | "DYNPREC" => ("gg58_dyn_resp_path", true),
-        "WALCS0" | "WALCS1" | "WALCS2" | "WALCS3" | "WALCS4" | "WALCS5" | "WALCS6" | "WALCS7" | "WALCS8" | "WALCS9" | "WALCS10" => ("gg59_area_limit", true),
+        "WALCS0" | "WALCS1" | "WALCS2" | "WALCS3" | "WALCS4" | "WALCS5" | "WALCS6" | "WALCS7" | "WALCS8" | "WALCS9"
+        | "WALCS10" => ("gg59_area_limit", true),
         "ORISOF" | "ORISON" => ("gg61_tool_orient_smooth", true),
         "RMBBL" | "RMIBL" | "RMEBL" | "RMNBL" => ("gg62_repos_non_modal", false),
-        "GFRAME[0]" | "GFRAME[1]" | "GFRAME[2]" | "GFRAME[3]" | "GFRAME[4]" | "GFRAME[5]" | "GFRAME[6]" | "GFRAME[7]" | "GFRAME[8]" | "GFRAME[9]" | "GFRAME[10]" | "GFRAME[11]" | "GFRAME[12]" | "GFRAME[13]" | "GFRAME[14]" | "GFRAME[15]" | "GFRAME[16]" | "GFRAME[17]" | "GFRAME[18]" | "GFRAME[19]" | "GFRAME[20]" | "GFRAME[21]" | "GFRAME[22]" | "GFRAME[23]" | "GFRAME[24]" | "GFRAME[25]" | "GFRAME[26]" | "GFRAME[27]" | "GFRAME[28]" | "GFRAME[29]" | "GFRAME[30]" | "GFRAME[31]" | "GFRAME[32]" | "GFRAME[33]" | "GFRAME[34]" | "GFRAME[35]" | "GFRAME[36]" | "GFRAME[37]" | "GFRAME[38]" | "GFRAME[39]" | "GFRAME[40]" | "GFRAME[41]" | "GFRAME[42]" | "GFRAME[43]" | "GFRAME[44]" | "GFRAME[45]" | "GFRAME[46]" | "GFRAME[47]" | "GFRAME[48]" | "GFRAME[49]" | "GFRAME[50]" | "GFRAME[51]" | "GFRAME[52]" | "GFRAME[53]" | "GFRAME[54]" | "GFRAME[55]" | "GFRAME[56]" | "GFRAME[57]" | "GFRAME[58]" | "GFRAME[59]" | "GFRAME[60]" | "GFRAME[61]" | "GFRAME[62]" | "GFRAME[63]" | "GFRAME[64]" | "GFRAME[65]" | "GFRAME[66]" | "GFRAME[67]" | "GFRAME[68]" | "GFRAME[69]" | "GFRAME[70]" | "GFRAME[71]" | "GFRAME[72]" | "GFRAME[73]" | "GFRAME[74]" | "GFRAME[75]" | "GFRAME[76]" | "GFRAME[77]" | "GFRAME[78]" | "GFRAME[79]" | "GFRAME[80]" | "GFRAME[81]" | "GFRAME[82]" | "GFRAME[83]" | "GFRAME[84]" | "GFRAME[85]" | "GFRAME[86]" | "GFRAME[87]" | "GFRAME[88]" | "GFRAME[89]" | "GFRAME[90]" | "GFRAME[91]" | "GFRAME[92]" | "GFRAME[93]" | "GFRAME[94]" | "GFRAME[95]" | "GFRAME[96]" | "GFRAME[97]" | "GFRAME[98]" | "GFRAME[99]" | "GFRAME[100]" => ("gg64_grinding_frames", true),
+        "GFRAME[0]" | "GFRAME[1]" | "GFRAME[2]" | "GFRAME[3]" | "GFRAME[4]" | "GFRAME[5]" | "GFRAME[6]"
+        | "GFRAME[7]" | "GFRAME[8]" | "GFRAME[9]" | "GFRAME[10]" | "GFRAME[11]" | "GFRAME[12]" | "GFRAME[13]"
+        | "GFRAME[14]" | "GFRAME[15]" | "GFRAME[16]" | "GFRAME[17]" | "GFRAME[18]" | "GFRAME[19]" | "GFRAME[20]"
+        | "GFRAME[21]" | "GFRAME[22]" | "GFRAME[23]" | "GFRAME[24]" | "GFRAME[25]" | "GFRAME[26]" | "GFRAME[27]"
+        | "GFRAME[28]" | "GFRAME[29]" | "GFRAME[30]" | "GFRAME[31]" | "GFRAME[32]" | "GFRAME[33]" | "GFRAME[34]"
+        | "GFRAME[35]" | "GFRAME[36]" | "GFRAME[37]" | "GFRAME[38]" | "GFRAME[39]" | "GFRAME[40]" | "GFRAME[41]"
+        | "GFRAME[42]" | "GFRAME[43]" | "GFRAME[44]" | "GFRAME[45]" | "GFRAME[46]" | "GFRAME[47]" | "GFRAME[48]"
+        | "GFRAME[49]" | "GFRAME[50]" | "GFRAME[51]" | "GFRAME[52]" | "GFRAME[53]" | "GFRAME[54]" | "GFRAME[55]"
+        | "GFRAME[56]" | "GFRAME[57]" | "GFRAME[58]" | "GFRAME[59]" | "GFRAME[60]" | "GFRAME[61]" | "GFRAME[62]"
+        | "GFRAME[63]" | "GFRAME[64]" | "GFRAME[65]" | "GFRAME[66]" | "GFRAME[67]" | "GFRAME[68]" | "GFRAME[69]"
+        | "GFRAME[70]" | "GFRAME[71]" | "GFRAME[72]" | "GFRAME[73]" | "GFRAME[74]" | "GFRAME[75]" | "GFRAME[76]"
+        | "GFRAME[77]" | "GFRAME[78]" | "GFRAME[79]" | "GFRAME[80]" | "GFRAME[81]" | "GFRAME[82]" | "GFRAME[83]"
+        | "GFRAME[84]" | "GFRAME[85]" | "GFRAME[86]" | "GFRAME[87]" | "GFRAME[88]" | "GFRAME[89]" | "GFRAME[90]"
+        | "GFRAME[91]" | "GFRAME[92]" | "GFRAME[93]" | "GFRAME[94]" | "GFRAME[95]" | "GFRAME[96]" | "GFRAME[97]"
+        | "GFRAME[98]" | "GFRAME[99]" | "GFRAME[100]" => ("gg64_grinding_frames", true),
         _ => return None,
     })
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -805,11 +805,7 @@ pub fn write_csv<W: std::io::Write>(table: &Table, writer: W) -> Result<(), std:
                     Column::Float(v) => v[row].map_or(String::new(), |f| format!("{:.3}", f)),
                     Column::Int(v) => v[row].map_or(String::new(), |i| i.to_string()),
                     Column::Str(v) => v[row].clone().unwrap_or_default(),
-                    Column::StrList(v) => v[row]
-                        .as_ref()
-                        .and_then(|l| l.get(copy))
-                        .cloned()
-                        .unwrap_or_default(),
+                    Column::StrList(v) => v[row].as_ref().and_then(|l| l.get(copy)).cloned().unwrap_or_default(),
                 });
             }
             w.write_record(&record)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -87,13 +87,18 @@ pub struct State {
 
 impl State {
     /// Creates a new State with the given axis identifiers and configuration.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `axis_identifiers` - List of valid axis names (e.g., ["X", "Y", "Z", "E"])
     /// * `iteration_limit` - Maximum number of iterations for loops
     /// * `axis_index_map` - Optional mapping of axis names to array indices (e.g., {"E": 4})
-    pub fn new(axis_identifiers: Vec<String>, iteration_limit: usize, axis_index_map: Option<HashMap<String, usize>>, allow_undefined_variables: bool) -> Self {
+    pub fn new(
+        axis_identifiers: Vec<String>,
+        iteration_limit: usize,
+        axis_index_map: Option<HashMap<String, usize>>,
+        allow_undefined_variables: bool,
+    ) -> Self {
         let mut symbols = HashMap::new();
         symbols.insert("TRUE".to_string(), 1.0);
         symbols.insert("FALSE".to_string(), 0.0);
@@ -192,11 +197,7 @@ impl State {
     /// call first materialized a throwaway `String` - a second full copy of the
     /// whole program, a wasted gigabyte on the largest inputs.
     pub fn set_input(&mut self, input: &str) {
-        self.line_offsets = input
-            .match_indices('\n')
-            .map(|(i, _)| i)
-            .collect::<Vec<_>>()
-            .into();
+        self.line_offsets = input.match_indices('\n').map(|(i, _)| i).collect::<Vec<_>>().into();
         self.input = Arc::from(input);
     }
 
@@ -210,10 +211,7 @@ impl State {
         } else {
             self.line_offsets.get(line_no - 2).map(|&i| i + 1)?
         };
-        let end = self.line_offsets
-            .get(line_no - 1)
-            .copied()
-            .unwrap_or(self.input.len());
+        let end = self.line_offsets.get(line_no - 1).copied().unwrap_or(self.input.len());
         Some(&self.input[start..end])
     }
 
@@ -276,13 +274,11 @@ impl State {
     /// Gets the array index for an axis, if a mapping exists
     pub fn get_axis_index(&self, axis: &str, line_no: usize, preview: &str) -> Result<usize, ParsingError> {
         if let Some(map) = &self.axis_index_map {
-            map.get(axis)
-                .copied()
-                .ok_or_else(|| ParsingError::MissingAxisMapping {
-                    line_no,
-                    preview: preview.to_string(),
-                    axis: axis.to_string(),
-                })
+            map.get(axis).copied().ok_or_else(|| ParsingError::MissingAxisMapping {
+                line_no,
+                preview: preview.to_string(),
+                axis: axis.to_string(),
+            })
         } else {
             Err(ParsingError::MissingAxisMapping {
                 line_no,

--- a/src/structure_scan.rs
+++ b/src/structure_scan.rs
@@ -125,9 +125,7 @@ pub fn check_structures(input: &str) -> Result<ProgramShape, ParsingError> {
                             open.closer()
                         ))
                     }
-                    None => {
-                        return error(format!("{} without a preceding {}", word, expected.opener()))
-                    }
+                    None => return error(format!("{} without a preceding {}", word, expected.opener())),
                 }
             }
             _ => {}
@@ -223,16 +221,13 @@ fn contains_goto_word(line: &str) -> bool {
     let mut search_start = 0;
     while let Some(found) = upper[search_start..].find("GOTO") {
         let start = search_start + found;
-        let preceded_ok = start == 0
-            || !(bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_');
+        let preceded_ok = start == 0 || !(bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_');
         let mut end = start + 4;
         // allow the F/B/C/S suffix
         if matches!(bytes.get(end), Some(b'F') | Some(b'B') | Some(b'C') | Some(b'S')) {
             end += 1;
         }
-        let followed_ok = !bytes
-            .get(end)
-            .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
+        let followed_ok = !bytes.get(end).is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_');
         if preceded_ok && followed_ok {
             return true;
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -48,7 +48,10 @@ fn flatten_tolerance_flag_yields_g1_only_csv() {
     let lines = run_cli(&dir, &["--flatten-tolerance", "0.1"]);
 
     let motions = motion_column(&lines);
-    assert!(motions.iter().all(|m| m == "G1"), "non-G1 motion in flattened CSV: {motions:?}");
+    assert!(
+        motions.iter().all(|m| m == "G1"),
+        "non-G1 motion in flattened CSV: {motions:?}"
+    );
     // The arc (~25 samples at 0.1 mm) and the spline expand well beyond the
     // 8 programmed blocks.
     assert!(motions.len() > 20, "arc/spline not expanded: {} rows", motions.len());


### PR DESCRIPTION
Runs `cargo fmt` over the whole crate and adds a `cargo fmt --check` gate to the `rust-test` CI job so formatting stays enforced.

- **Formatting only** — no logic changes. The repo had drifted from the current rustfmt style; this is the one-time reformat (12 files).
- Also removes trailing whitespace inside the `UndefinedVariable` struct literal in `interpret_rules.rs` that made `cargo fmt` itself **error** ("left behind trailing whitespace"). Without that fix the new `--check` gate would be red on a clean checkout.
- `cargo test` green; `cargo fmt --check` clean.

Intended as the **last** merge — after #50 and #52 — since a tree-wide reformat conflicts with any outstanding branch. I can rebase it once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3