### PR TITLE
Structured error locations via NcError (line/column as data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ released to PyPI.
   block's line number; `dataframe_to_nc` ignores it (source provenance, not an
   emittable word). Concatenating batches reconstructs the same per-row
   `line_no` as the whole-file dataframe (#45)
+- Structured error locations: parse/interpret failures now raise
+  `nc_gcode_interpreter.NcError` (a `ValueError` subclass, so existing
+  `except ValueError` keeps working) carrying the position as data - `.line`,
+  `.column` (syntax errors), `.context`, and `.line_text` attributes (each an
+  int / str or `None`) - so a caller (e.g. an editor) can locate the offending
+  token without regex-parsing the message. `str(err)` is unchanged
 
 ### Fixed
 

--- a/python/nc_gcode_interpreter/__init__.py
+++ b/python/nc_gcode_interpreter/__init__.py
@@ -3,6 +3,7 @@ import os
 import polars as pl
 from ._internal import nc_to_rows as _nc_to_rows
 from ._internal import nc_to_batches as _nc_to_batches
+from ._internal import NcError
 from ._internal import __doc__  # noqa: F401
 import json
 from pathlib import Path
@@ -21,6 +22,7 @@ __all__ = [
     "nc_to_batches",
     "sanitize_dataframe",
     "dataframe_to_nc",
+    "NcError",
 ]
 
 # Batch size nc_to_dataframe uses internally when draining the batch stream it

--- a/python/nc_gcode_interpreter/_internal.pyi
+++ b/python/nc_gcode_interpreter/_internal.pyi
@@ -5,6 +5,15 @@ from typing import Any, Iterator, Optional, List, Dict, Tuple
 # wrapper imports are declared here. Signatures mirror the `#[pyo3(signature)]`
 # defaults in src/lib.rs.
 
+class NcError(ValueError):
+    """NC parse/interpret error carrying structured location data. Subclasses
+    ValueError so `except ValueError` keeps working."""
+
+    line: Optional[int]
+    column: Optional[int]
+    context: Optional[str]
+    line_text: Optional[str]
+
 def nc_to_rows(
     input: str,
     initial_state: Optional[str] = None,

--- a/python/tests/test_structured_errors.py
+++ b/python/tests/test_structured_errors.py
@@ -1,0 +1,50 @@
+"""NcError exposes an error's source location as data (line / column / context
+/ line_text) instead of only as a formatted string, while remaining a
+ValueError subclass so existing `except ValueError` handlers keep working."""
+
+import pytest
+from nc_gcode_interpreter import NcError, nc_to_dataframe
+
+
+def test_nc_error_is_a_value_error_subclass():
+    assert issubclass(NcError, ValueError)
+    with pytest.raises(ValueError):
+        nc_to_dataframe("X=R99\n")  # undefined variable
+
+
+def test_syntax_error_carries_line_and_column():
+    # The malformed token is on line 2; the parser reports its column.
+    with pytest.raises(NcError) as exc:
+        nc_to_dataframe("G1 X10\nX20 Y((\nX30\n")
+    e = exc.value
+    assert e.line == 2
+    assert isinstance(e.column, int) and e.column > 0
+    assert e.line_text == "X20 Y(("
+    assert e.context == "line parsing"
+
+
+def test_semantic_error_carries_line_but_no_column():
+    # An undefined-variable error is anchored to a line, not a column.
+    with pytest.raises(NcError) as exc:
+        nc_to_dataframe("X=R99\n")
+    e = exc.value
+    assert e.line == 1
+    assert e.column is None
+    assert e.line_text == "X=R99"
+
+
+def test_location_attributes_always_present():
+    # Every NcError has the four attributes, even when a value is None, so
+    # callers can read them unconditionally.
+    with pytest.raises(NcError) as exc:
+        nc_to_dataframe("G999 X1\n")  # unknown G code
+    e = exc.value
+    assert e.line == 1
+    for attr in ("line", "column", "context", "line_text"):
+        assert hasattr(e, attr)
+
+
+def test_str_is_still_the_full_message():
+    with pytest.raises(NcError) as exc:
+        nc_to_dataframe("X=R99\n")
+    assert "Undefined variable" in str(exc.value)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,10 @@ Details: {message}
 "#)]
     ParsingContext {
         line_no: usize,
+        /// 1-based column of the offending token when known (syntax errors
+        /// carry it from the pest span); `None` for errors located only to a
+        /// line. Not shown in the formatted message, only exposed as data.
+        column: Option<usize>,
         preview: String,
         context: String,
         message: String,
@@ -189,6 +193,22 @@ Details: Function {name} expects {expected} argument(s), but received {actual}.
     },
 }
 
+/// Structured location of an error, for callers that want the position as data
+/// rather than parsing it out of the formatted message (e.g. an editor
+/// highlighting the offending token). Exposed to Python as attributes on the
+/// `NcError` exception.
+#[derive(Debug, Clone, Default)]
+pub struct ErrorLocation {
+    /// 1-based source line the error is anchored to.
+    pub line: usize,
+    /// 1-based column when known (syntax errors), else `None`.
+    pub column: Option<usize>,
+    /// Which stage/construct was being parsed, when the variant records it.
+    pub context: Option<String>,
+    /// The source line's text, when captured.
+    pub line_text: Option<String>,
+}
+
 impl ParsingError {
     pub fn with_context<T: AsRef<str>>(
         line_no: usize,
@@ -198,9 +218,57 @@ impl ParsingError {
     ) -> Self {
         Self::ParsingContext {
             line_no,
+            column: None,
             preview: preview.as_ref().to_string(),
             context: context.as_ref().to_string(),
             message: message.as_ref().to_string(),
+        }
+    }
+
+    /// The error's source location as structured data, or `None` for errors
+    /// not tied to a specific line (stream closed, element-count mismatches,
+    /// etc.). `line_text`/`context`/`column` are populated when the variant
+    /// carries them.
+    pub fn location(&self) -> Option<ErrorLocation> {
+        let some = |line: usize,
+                    column: Option<usize>,
+                    context: Option<&str>,
+                    preview: Option<&str>| {
+            Some(ErrorLocation {
+                line,
+                column,
+                context: context.map(str::to_string),
+                line_text: preview.map(str::to_string),
+            })
+        };
+        match self {
+            Self::ParsingContext { line_no, column, preview, context, .. } => {
+                some(*line_no, *column, Some(context), Some(preview))
+            }
+            Self::UnexpectedRule { line_no, preview, context, .. } => {
+                some(*line_no, None, Some(context), Some(preview))
+            }
+            Self::UnknownVariable { line_no, preview, .. }
+            | Self::UndefinedVariable { line_no, preview, .. }
+            | Self::TooManyMCommands { line_no, preview, .. }
+            | Self::MissingAxisMapping { line_no, preview, .. }
+            | Self::InvalidAxisIndex { line_no, preview, .. }
+            | Self::UnsupportedStatement { line_no, preview, .. }
+            | Self::JumpTargetNotFound { line_no, preview, .. }
+            | Self::UnmatchedStructure { line_no, preview, .. }
+            | Self::UnknownGCommand { line_no, preview, .. }
+            | Self::InvalidFunctionArity { line_no, preview, .. } => {
+                some(*line_no, None, None, Some(preview))
+            }
+            Self::ParseError { .. }
+            | Self::InvalidElementCount { .. }
+            | Self::InvalidCondition
+            | Self::UnexpectedOperator { .. }
+            | Self::LoopLimit { .. }
+            | Self::StreamClosed
+            | Self::UnexpectedAxis { .. }
+            | Self::AxisUsedAsVariable { .. }
+            | Self::ReservedNameUsedAsVariable { .. } => None,
         }
     }
 }
@@ -208,5 +276,40 @@ impl ParsingError {
 impl From<ParsingError> for std::io::Error {
     fn from(err: ParsingError) -> std::io::Error {
         std::io::Error::new(std::io::ErrorKind::Other, err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn location_extracts_line_column_context_and_text() {
+        // A syntax error carries a column; the others locate to a line only.
+        let syntax = ParsingError::ParsingContext {
+            line_no: 2,
+            column: Some(8),
+            preview: "X20 Y((".to_string(),
+            context: "line parsing".to_string(),
+            message: "unexpected".to_string(),
+        };
+        let loc = syntax.location().expect("has location");
+        assert_eq!(loc.line, 2);
+        assert_eq!(loc.column, Some(8));
+        assert_eq!(loc.context.as_deref(), Some("line parsing"));
+        assert_eq!(loc.line_text.as_deref(), Some("X20 Y(("));
+
+        let semantic = ParsingError::UndefinedVariable {
+            line_no: 1,
+            preview: "X=R99".to_string(),
+            name: "R99".to_string(),
+        };
+        let loc = semantic.location().expect("has location");
+        assert_eq!((loc.line, loc.column), (1, None));
+        assert_eq!(loc.line_text.as_deref(), Some("X=R99"));
+
+        // Errors with no source anchor return None.
+        assert!(ParsingError::StreamClosed.location().is_none());
+        assert!(ParsingError::InvalidCondition.location().is_none());
     }
 }

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -279,6 +279,7 @@ fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f
     let func_name = pairs.next()
         .ok_or_else(|| ParsingError::ParsingContext {
             line_no,
+            column: None,
             preview: preview.clone(),
             context: "function evaluation".to_string(),
             message: "Missing function name".to_string(),
@@ -288,6 +289,7 @@ fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f
     let args_pair = pairs.next()
         .ok_or_else(|| ParsingError::ParsingContext {
             line_no,
+            column: None,
             preview: preview.clone(),
             context: "function evaluation".to_string(),
             message: "Missing function arguments".to_string(),
@@ -388,6 +390,7 @@ fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f
             if min > max {
                 return Err(ParsingError::ParsingContext {
                     line_no,
+                    column: None,
                     preview,
                     context: "BOUND".to_string(),
                     message: format!("BOUND minimum ({}) is greater than maximum ({})", min, max),
@@ -405,6 +408,7 @@ fn evaluate_arithmetic_function(pair: Pair<Rule>, state: &mut State) -> Result<f
         },
         other => Err(ParsingError::ParsingContext {
             line_no,
+            column: None,
             preview,
             context: "expression".to_string(),
             message: format!("'{}' is not a known arithmetic function", other),
@@ -571,6 +575,7 @@ fn evaluate_multiplicative(pairs: &[Pair<Rule>], pos: &mut usize, state: &mut St
                 if rhs == 0.0 {
                     return Err(ParsingError::ParsingContext {
                         line_no,
+                        column: None,
                         preview,
                         context: "integer division".to_string(),
                         message: "Integer division (DIV) by zero".to_string(),
@@ -608,6 +613,7 @@ fn evaluate_unary(pairs: &[Pair<Rule>], pos: &mut usize, state: &mut State) -> R
             .unwrap_or((0, "(could not retrieve line)".to_string()));
         ParsingError::ParsingContext {
             line_no,
+            column: None,
             preview,
             context: "evaluate_unary".to_string(),
             message: "Expected an operand at end of expression".to_string(),
@@ -1114,6 +1120,7 @@ fn interpret_identifier(pair: Pair<Rule>) -> Result<String, ParsingError> {
     } else {
         Err(ParsingError::ParsingContext {
             line_no,
+            column: None,
             preview,
             context: "identifier parsing".to_string(),
             message: format!("Found '{:?}' but expected an identifier", pair.as_rule()),
@@ -1521,6 +1528,7 @@ fn interpret_goto(pair: Pair<Rule>, state: &State) -> Result<BlockFlow, ParsingE
         other => {
             return Err(ParsingError::ParsingContext {
                 line_no,
+                column: None,
                 preview,
                 context: "jump statement".to_string(),
                 message: format!("Unexpected jump keyword '{}'", other),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -231,12 +231,18 @@ fn interpret_file(input: &str, state: &mut State, output: &mut OutputRows) -> Re
 
     let file = NCParser::parse(Rule::file, input)
         .map_err(|e| {
-            let (line, _col) = match &e.line_col {
+            let (line, col) = match &e.line_col {
                 pest::error::LineColLocation::Pos(pos) => *pos,
                 pest::error::LineColLocation::Span(start, _) => *start,
             };
             let preview = state.get_line(line).unwrap_or("(could not retrieve line)").to_string();
-            ParsingError::with_context(line, preview, "initial file parsing".to_string(), describe_parse_error(&e))
+            ParsingError::ParsingContext {
+                line_no: line,
+                column: Some(col),
+                preview,
+                context: "initial file parsing".to_string(),
+                message: describe_parse_error(&e),
+            }
         })?
         .next()
         .ok_or_else(|| ParsingError::ParseError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,55 @@ mod python_bindings {
     }
     use std::sync::{mpsc, Mutex};
 
+    use crate::errors::ErrorLocation;
     use crate::interpreter::{nc_to_batch_stream_with_line_numbers, nc_to_row_stream};
     use crate::output::{is_forward_filled_column, is_string_column, Column, Row, Table};
     use crate::types::Value;
+
+    pyo3::create_exception!(
+        _internal,
+        NcError,
+        PyValueError,
+        "NC parse/interpret error. Subclasses ValueError (so `except ValueError` \
+         still catches it) and carries the error's source location as data: the \
+         `line`, `column`, `context`, and `line_text` attributes (each an int / \
+         str, or None when not applicable). `str(err)` is the full formatted \
+         message as before."
+    );
+
+    /// An error crossing the worker channel: the formatted message plus the
+    /// structured location, so the consuming thread can raise an `NcError`
+    /// carrying both.
+    struct ErrInfo {
+        message: String,
+        location: Option<ErrorLocation>,
+    }
+
+    impl ErrInfo {
+        fn from_error(error: &crate::errors::ParsingError) -> Self {
+            ErrInfo {
+                message: error.to_string(),
+                location: error.location(),
+            }
+        }
+
+        /// Build the Python `NcError`, always setting the four location
+        /// attributes (None when absent) so callers can read them
+        /// unconditionally.
+        fn into_pyerr(self, py: Python<'_>) -> PyErr {
+            let err = NcError::new_err(self.message);
+            let value = err.value(py);
+            let (line, column, context, line_text) = match self.location {
+                Some(l) => (Some(l.line), l.column, l.context, l.line_text),
+                None => (None, None, None, None),
+            };
+            let _ = value.setattr("line", line);
+            let _ = value.setattr("column", column);
+            let _ = value.setattr("context", context);
+            let _ = value.setattr("line_text", line_text);
+            err
+        }
+    }
 
     /// Build one Arrow [`RecordBatch`](arrow::record_batch::RecordBatch) directly
     /// from an output [`Table`], in column order. Each [`Column`] becomes an Arrow
@@ -150,11 +196,11 @@ mod python_bindings {
         flatten_tolerance: Option<f64>,
     ) -> PyResult<(
         mpsc::Receiver<Row>,
-        mpsc::Receiver<Result<FinalState, String>>,
+        mpsc::Receiver<Result<FinalState, ErrInfo>>,
         std::thread::JoinHandle<()>,
     )> {
         let (row_sender, row_receiver) = mpsc::sync_channel::<Row>(1024);
-        let (result_sender, result_receiver) = mpsc::sync_channel::<Result<FinalState, String>>(1);
+        let (result_sender, result_receiver) = mpsc::sync_channel::<Result<FinalState, ErrInfo>>(1);
 
         let handle = std::thread::Builder::new()
             .name("nc-interpreter".to_string())
@@ -174,7 +220,7 @@ mod python_bindings {
                     Ok(state) => Ok(state.to_python_dict()),
                     // The consumer hung up: nothing to report to nobody.
                     Err(crate::errors::ParsingError::StreamClosed) => return,
-                    Err(error) => Err(format!("{}", error)),
+                    Err(error) => Err(ErrInfo::from_error(&error)),
                 };
                 let _ = result_sender.send(message);
             })
@@ -203,14 +249,14 @@ mod python_bindings {
         emit_line_no: bool,
     ) -> PyResult<(
         mpsc::Receiver<Table>,
-        mpsc::Receiver<Result<FinalState, String>>,
+        mpsc::Receiver<Result<FinalState, ErrInfo>>,
         std::thread::JoinHandle<()>,
     )> {
         // A cap of 3 lets the worker build one batch ahead while the consumer
         // converts the previous one to a polars DataFrame, without unbounded
         // buffering.
         let (batch_sender, batch_receiver) = mpsc::sync_channel::<Table>(3);
-        let (result_sender, result_receiver) = mpsc::sync_channel::<Result<FinalState, String>>(1);
+        let (result_sender, result_receiver) = mpsc::sync_channel::<Result<FinalState, ErrInfo>>(1);
 
         let handle = std::thread::Builder::new()
             .name("nc-interpreter".to_string())
@@ -233,7 +279,7 @@ mod python_bindings {
                     Ok(state) => Ok(state.to_python_dict()),
                     // The consumer hung up: nothing to report to nobody.
                     Err(crate::errors::ParsingError::StreamClosed) => return,
-                    Err(error) => Err(format!("{}", error)),
+                    Err(error) => Err(ErrInfo::from_error(&error)),
                 };
                 let _ = result_sender.send(message);
             })
@@ -253,7 +299,7 @@ mod python_bindings {
     #[pyclass]
     struct NcRowIterator {
         rows: Option<Mutex<mpsc::Receiver<crate::output::Row>>>,
-        result: Option<Mutex<mpsc::Receiver<Result<FinalState, String>>>>,
+        result: Option<Mutex<mpsc::Receiver<Result<FinalState, ErrInfo>>>>,
         handle: Option<std::thread::JoinHandle<()>>,
         /// Running forward-fill values, keyed by interned column name.
         fill: HashMap<&'static str, Value>,
@@ -305,9 +351,9 @@ mod python_bindings {
                 let receiver = result.into_inner().expect("result receiver mutex poisoned");
                 match py.detach(move || receiver.recv()) {
                     Ok(Ok(state)) => self.state = Some(state),
-                    Ok(Err(message)) => {
+                    Ok(Err(info)) => {
                         self.join();
-                        return Err(PyErr::new::<PyValueError, _>(message));
+                        return Err(info.into_pyerr(py));
                     }
                     Err(_) => {}
                 }
@@ -473,7 +519,7 @@ mod python_bindings {
     #[pyclass]
     struct NcBatchIterator {
         batches: Option<Mutex<mpsc::Receiver<Table>>>,
-        result: Option<Mutex<mpsc::Receiver<Result<FinalState, String>>>>,
+        result: Option<Mutex<mpsc::Receiver<Result<FinalState, ErrInfo>>>>,
         handle: Option<std::thread::JoinHandle<()>>,
         state: Option<FinalState>,
     }
@@ -484,9 +530,9 @@ mod python_bindings {
                 let receiver = result.into_inner().expect("result receiver mutex poisoned");
                 match py.detach(move || receiver.recv()) {
                     Ok(Ok(state)) => self.state = Some(state),
-                    Ok(Err(message)) => {
+                    Ok(Err(info)) => {
                         self.join();
-                        return Err(PyErr::new::<PyValueError, _>(message));
+                        return Err(info.into_pyerr(py));
                     }
                     Err(_) => {}
                 }
@@ -611,6 +657,7 @@ mod python_bindings {
         m.add_function(wrap_pyfunction!(nc_to_batches, m)?)?;
         m.add_class::<NcRowIterator>()?;
         m.add_class::<NcBatchIterator>()?;
+        m.add("NcError", m.py().get_type::<NcError>())?;
         Ok(())
     }
 }

--- a/src/line_driver.rs
+++ b/src/line_driver.rs
@@ -511,12 +511,17 @@ fn parse_single_line<'i>(
 ) -> Result<Pair<'i, Rule>, ParsingError> {
     let parsed = NCParser::parse(Rule::line_entry, padded).map_err(|e| {
         let preview = state.get_line(line_no).unwrap_or("(could not retrieve line)").to_string();
-        ParsingError::with_context(
+        let col = match &e.line_col {
+            pest::error::LineColLocation::Pos(pos) => pos.1,
+            pest::error::LineColLocation::Span(start, _) => start.1,
+        };
+        ParsingError::ParsingContext {
             line_no,
+            column: Some(col),
             preview,
-            "line parsing".to_string(),
-            crate::interpreter::describe_parse_error(&e),
-        )
+            context: "line parsing".to_string(),
+            message: crate::interpreter::describe_parse_error(&e),
+        }
     })?;
     parsed
         .flatten()


### PR DESCRIPTION
Targets **0.2.1**. Answers "do we need parsable error messages so line/column of a syntax error is available as data, not only a string?" — yes, and here it is.

## What
Parse/interpret failures now raise `nc_gcode_interpreter.NcError` instead of a bare `ValueError`:
- `NcError` **subclasses `ValueError`** → existing `except ValueError` handlers keep working (non-breaking).
- Carries location **as data**: `.line`, `.column`, `.context`, `.line_text` (each `int`/`str` or `None`).
- `str(err)` is the same formatted message as before.

```python
from nc_gcode_interpreter import NcError, nc_to_dataframe
try:
    nc_to_dataframe("G1 X10\nX20 Y((\nX30\n")
except NcError as e:
    e.line, e.column, e.context, e.line_text
    # 2, 8, 'line parsing', 'X20 Y(('
```

## How
- `ParsingError` already carried `line_no` per variant; added `ErrorLocation` + `ParsingError::location()` to surface line/column/context/line_text uniformly. **Column** is captured for syntax errors (pest's span already had it — both the stage-1 per-line path and the whole-file fallback); semantic errors (undefined var, unknown G code, …) locate to a line.
- The worker channels now carry a structured `ErrInfo { message, location }` instead of a pre-formatted `String`, so the location survives the thread hop. Both stream iterators raise `NcError` with all four attributes always set (None when N/A).

## Tests
- Rust: `location()` extraction (syntax w/ column, semantic w/o, None for anchorless errors).
- Python: line+column on syntax errors, line-only on semantic, `issubclass(NcError, ValueError)` + `raises(ValueError)` back-compat, attributes-always-present, `str()` unchanged.
- `cargo test` green; `pytest` 312 passed; `ruff`/`mypy` clean.

Independent of #50/#52/#54; will need the usual CHANGELOG consolidation into the single `[v0.2.1]` at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RX8t1oNZLCC9CL8SfHEyg3