### PR TITLE
feat(#47): execution-cursor VM + checkpoint/resume foundation (opt-in via NC_VM)

### DIFF
--- a/docs/resumable-interpretation-design.md
+++ b/docs/resumable-interpretation-design.md
@@ -1,7 +1,10 @@
 # Resumable interpretation — checkpoint/resume design (#47, targeting 0.3.0)
 
-Status: **design draft**. This document scopes the resumable-`NcSession` feature
-requested in issue #47 and the interpreter change it requires. No code yet.
+Status: **design + proof-of-concept**. This document scopes the resumable-`NcSession`
+feature requested in issue #47 and the interpreter change it requires. A working
+Phase-1 proof of concept — the execution-cursor VM (`src/vm.rs`, opt-in via
+`NC_VM=1`) plus in-memory checkpoint/resume — now exists alongside this design;
+the public API and Phases 2–3 remain future work.
 
 ## 1. Goal and consumer requirements
 

--- a/docs/resumable-interpretation-design.md
+++ b/docs/resumable-interpretation-design.md
@@ -1,0 +1,230 @@
+# Resumable interpretation — checkpoint/resume design (#47, targeting 0.3.0)
+
+Status: **design draft**. This document scopes the resumable-`NcSession` feature
+requested in issue #47 and the interpreter change it requires. No code yet.
+
+## 1. Goal and consumer requirements
+
+Expose a resumable interpretation handle:
+
+- `checkpoint() -> token` — capture the complete execution position roughly
+  every *N* output rows.
+- `resume(token, patched_text)` — restart interpretation from a checkpoint,
+  against an edited program.
+
+Consumer: ribweaver `/sim` phase-E *incremental re-interpret* for multi-million-row
+loop expansions. When the user edits source line *L*, it resumes from the last
+checkpoint whose block cursor precedes *L* instead of re-running the whole program.
+Downstream is evidence-gated: debounced-full re-interpret is fine below ~10⁵ rows,
+so the resume path only has to pay off for the *giant* case — which is exactly the
+hard one, because a million-row expansion is typically **one** top-level `WHILE`/`LOOP`.
+Top-level-only checkpoints would yield a single checkpoint for the whole expansion
+and be useless; checkpoints must be capturable **mid-loop**.
+
+Cancellation already exists (drop the iterator → `StreamClosed`); resume composes
+with it as the latest-wins primitive.
+
+## 2. Why this is hard — the crux
+
+The issue's premise ("no call stack exists, so block-granularity checkpoints are
+tractable") is half right. There is no *subprogram* call stack (#48), but the
+**control structures form an implicit stack**, and the instruction pointer lives
+on the **Rust call stack**, not in any serializable structure.
+
+Precise findings (`src/interpret_rules.rs`):
+
+- The instruction pointer is `index: usize`, a **stack-local** in `run_blocks`
+  (`:2071-2103`) — one per active scope. There is no IP counter in `State`.
+- Every control construct drives its body by **recursively calling**
+  `interpret_blocks`, holding borrowed `Pair<Rule>` iterators and a `loop_count`
+  as stack locals: `WHILE` (`:1386`), `LOOP` (`:1413`), `FOR` (`:1434`),
+  `REPEAT/UNTIL` (`:1493`), `IF/ELSE` (`:1305`), `CASE` (`:1623`).
+- `Pair<Rule>` is `pest::iterators::Pair<'i, Rule>` — a **borrowed cursor into the
+  parse tree**, tied to the lifetime of the input `&str`. Execution positions are
+  expressed as *paths within the pest tree*: inherently non-serializable.
+- `loop_count` (WHILE/LOOP/REPEAT) is **purely stack-local** — not reflected in
+  `State`. `FOR`'s counter *is* in `symbol_table`, but its `end_value` bound and
+  `variable_name` are stack-local. Loop *conditions* re-evaluate from `State` each
+  iteration, so they are re-derivable — but the position within the tree is not.
+- `IF` branch choice is implicit in *which recursive call is currently live*.
+- `BlockFlow::Jump` bubbles up through scopes via `resolve_jump` (`:184`); an
+  unresolved jump propagates to the enclosing `run_blocks` (`:2098`) — that is how
+  a jump leaves a loop or IF body. `EndProgram` (M2/M17/M30) terminates.
+
+**Paused three loops deep inside an IF**, the resume position that is *not* in
+`State` is: each nested `index`, each `jumps_taken`, each `loop_count`, each loop's
+cached `end_value`/condition/blocks pest pairs, the live IF branch, and every
+`block_pairs` slice cursor — all borrowed views into the pest tree.
+
+So mid-loop resume requires **reifying the control stack** into an explicit,
+serializable structure: replacing recursion with an execution cursor.
+
+## 3. Convergence — this is already on the roadmap
+
+`docs/sinumerik-execution-model.md` §"Scaling limits and the road to streaming",
+point 4, already prescribes this exact change for gigabyte-scale programs:
+
+> *Execution cursor* instead of recursion, yielding `(line_no, row)` — … makes
+> seek-by-checkpoint (snapshot of `pc` + `State`) cheap.
+
+So #47 is **not a throwaway rewrite**. The execution cursor it needs is the same
+one already planned for streaming/scaling. Reifying the control stack:
+
+1. unblocks checkpoint/resume (#47),
+2. unblocks O(1)-start lazy streaming for >10⁷-line programs, and
+3. removes the deep-recursion stack-depth risk on pathological nesting.
+
+One change, three payoffs — that is the argument for spending a 0.3.0 on it.
+
+## 4. What a checkpoint must capture (full inventory)
+
+Assembled from a line-anchored audit of the three state-bearing subsystems.
+
+### 4.1 `State` (`src/state.rs:52-86`) — already `#[derive(Clone)]`, cheap
+`axes`, `symbol_table`, `string_table`, `translation`, `jump_scopes` (label sets,
+mirrors scope depth but not the index within each), `seen_jump_targets`,
+`warned_addresses`; config (`axis_identifiers`, `iteration_limit`,
+`axis_index_map`, `allow_undefined_variables`, `output_keys`); `input`/`line_offsets`
+shared via `Arc` so clone is O(live symbols). ✅ Already snapshot-ready in memory.
+
+### 4.2 Control-flow position (`src/interpret_rules.rs`) — THE reified stack
+Not in `State` today; must become an explicit `Vec<Frame>`:
+- per scope: `index` (IP), `jumps_taken`;
+- per loop frame: kind (WHILE/LOOP/FOR/REPEAT), `loop_count`, and cached bounds
+  (`FOR` `end_value` + `variable_name`);
+- the scope/branch identity (which blocks list, which IF branch) as a **stable
+  address**, not a borrowed pest `Pair`.
+
+### 4.3 Flattener (`src/flatten.rs:130-150`) — NOT currently `Clone`
+- Reconstructable from `new(tolerance, axis_identifiers)`: `tolerance`,
+  `geometric_axes`.
+- Must snapshot: `positions`, `motion` (modal), `plane` (modal), `spline_buffer`
+  (raw buffered `Row`s of an in-progress multi-block spline — no compressed form,
+  capture verbatim), `spline_start`, `spline_degree`, `warned_motions` (warn-once).
+- Blockers: `SplineItem` needs a `Clone` derive (mechanical; wraps `Row: Clone`);
+  interned `&'static str` keys re-intern via `intern_column` on *disk* restore only.
+
+### 4.4 Output pipeline (`src/output.rs`)
+- `OutputRows::current` — the **in-flight row** for the block being interpreted
+  (not yet flushed to the sink); `warned_g91` latch. A checkpoint between blocks
+  must capture `current` together with the sink, and reproduce the
+  flush-on-next-`start_row` ordering so no row is dropped or double-emitted.
+- Batch path forward-fill carry (`BatchBuilder`): `columns` (growing canonical
+  set, monotonic — resuming with an empty set changes later-batch schema),
+  `fill` (last-seen value per forward-filled column — the core carry).
+- `BatchStreamSink`: `buffer` (rows since last emitted batch), `events`,
+  `name_ids`, `output_row_count` (drives `row_idx` attribution and batch cadence).
+- Plumbing that a checkpoint *cannot* recreate: the channel handles (`Stream`
+  sender, batch `sender`, `events_sender`). Resume attaches fresh channels.
+- Process-global (outside any checkpoint): the `intern_column` `OnceLock` pool —
+  serialize key *content*, rehydrate through `intern_column`.
+
+## 5. Design: the reified execution VM
+
+### 5.1 Addressing a position without a borrowed pest `Pair`
+The single change that makes everything else fall out: express an execution
+position as a **stable, owned address** instead of a `pest::Pair` cursor.
+
+Two candidate representations:
+
+- **(a) Path into the retained tree.** Keep the parse tree alive (already `Arc`-able
+  via the input) and address a block by a `Vec<u32>` path of child indices from the
+  root. Serializable (just integers); resolved to a `Pair` by walking `into_inner`.
+  Smallest change; still tied to pest at runtime.
+- **(b) Pre-flattened owned IR (the execution cursor).** One whole-file pass lowers
+  the block/control tree into an owned, indexable program: a `Vec` of block
+  instructions with explicit scope boundaries and pre-resolved jump tables (a
+  whole-program `scan_jump_targets`). Execution is a `pc` over the IR with an
+  explicit frame stack; pest is gone at runtime. This is the roadmap's "execution
+  cursor" — larger, but unlocks lazy parse (Phase 3) and full serialization.
+
+**Recommendation: target (b).** It is the roadmap direction; doing (a) then (b) is
+double work. (a) is a viable *interim* only if we need #47 shipped before the IR
+lands.
+
+### 5.2 The frame stack and the token
+```
+Frame = { scope: ScopeId, ip: u32, jumps_taken: u32, loop: Option<LoopState> }
+LoopState = While { count } | Loop { count } | Repeat { count }
+          | For { count, var: SymbolId, end: f64 }
+Checkpoint = {
+    program_fingerprint,          // structural hash of the program prefix ≤ cursor
+    stack: Vec<Frame>,            // the reified control stack (innermost last)
+    state: State,                 // cloned
+    flattener: FlattenerSnapshot, // §4.3 evolving fields
+    output_carry: OutputCarry,    // §4.4 forward-fill + counts + in-flight row
+    cursor_line_no: u32,          // for the consumer's "checkpoint precedes L" gate
+}
+```
+Loop conditions are **not** stored — they re-evaluate from `state` on resume,
+exactly as the interpreter does each iteration today. That is what keeps the token
+small and correct.
+
+### 5.3 `checkpoint()` / `resume()` semantics
+- `checkpoint()` is valid only at a **between-rows boundary** (`output.start_row`,
+  `interpret_rules.rs:2005`) where the in-flight `current` row is well-defined.
+  Emit checkpoints every *N* output rows.
+- `resume(token, patched_text)`:
+  1. Re-lower `patched_text` to the IR.
+  2. Verify `program_fingerprint` against the patched program's prefix up to
+     `cursor_line_no`. If the edit changed block structure *before* the cursor, the
+     stored `ip`/`ScopeId`s are stale → **fail loudly** (`ParsingError`, a new
+     `kind = "checkpoint_invalidated"`), never resume into a shifted tree. This
+     matches the consumer's own gate ("last checkpoint whose block cursor precedes
+     L") and the project's loud-failure-over-silent-wrongness rule.
+  3. Restore `state` + frame stack + flattener + output carry; attach fresh output
+     channels; continue the VM loop from `stack`.
+
+### 5.4 Resume + edited text — the validity contract
+A checkpoint is resumable against a patched program **iff the patch lies at or
+after the checkpoint's block cursor**. Enforced by the prefix fingerprint. The
+consumer already honours this; the API makes it a checked invariant rather than a
+convention.
+
+## 6. Phasing
+
+- **Phase 1 — reify the stack (delivers #47).** Replace the recursive tree-walk in
+  `run_blocks`/`interpret_*` with the explicit VM + frame stack over IR (b), keeping
+  eager whole-file parse. Add `NcSession` with in-memory, **same-process**
+  `checkpoint()`/`resume()` (token holds owned `State`/frames/snapshots; no disk
+  serialization yet). This is everything the consumer needs.
+- **Phase 2 — serializable token.** `Serialize`/`Deserialize` for the snapshots;
+  re-intern `&'static str` keys on load; address symbols/scopes by stable ids.
+  Only if cross-process/persisted checkpoints are wanted.
+- **Phase 3 — lazy parse / O(1) start.** The streaming payoff: lazy per-line parse
+  feeding the same VM, demoting pest to the rare structural lines (the two-pass
+  design already prototyped in `src/line_driver.rs`). Independent follow-on.
+
+Phases 2 and 3 are optional and can slip past 0.3.0; Phase 1 is the release.
+
+## 7. Correctness strategy
+
+The VM must be a **behaviour-preserving** refactor of the tree-walker before
+`checkpoint` is even exposed. Guardrails:
+
+- **Differential parity**: run the whole existing golden-file suite + the mill-sim
+  corpus through both the old recursive path and the new VM, asserting byte-identical
+  output — the same discipline `test_stage1.py` already uses for the line-driver.
+- **Checkpoint/resume equivalence**: for a program run straight through vs.
+  checkpointed-and-resumed at every row boundary, assert identical `(line_no, row)`
+  streams and identical final `State` — including the hard cases: mid-`WHILE`,
+  mid-`FOR` (counter in `State`, bound in the frame), mid-spline (buffered
+  `spline_buffer`), a jump out of a loop body, and forward-fill continuity across a
+  resumed batch boundary.
+- **Invalidation**: edits before the cursor must fail loudly, never silently resume.
+
+## 8. Rough scope
+
+Phase 1 is real interpreter surgery — the IR lowering, the VM loop, the frame
+stack, `FlattenerSnapshot`/`OutputCarry` capture-restore, and the parity harness —
+but it is bounded and well-understood after this audit, and it is load-bearing for
+the streaming roadmap regardless of #47. Estimate: the dominant 0.3.0 work item.
+Phases 2–3 are additive and independently schedulable.
+
+## 9. Open questions for review
+- (b) IR now vs (a) tree-path interim — how urgently does the consumer need #47
+  relative to the streaming work? If both are wanted this quarter, go straight to (b).
+- Token type: opaque handle only (Phase 1) vs. a documented serializable schema —
+  affects how much of §5.2 is public API from day one.
+- Checkpoint cadence policy: fixed *N* rows vs. adaptive (e.g. denser near loop
+  headers so an edit resumes closer to *L*).

--- a/src/interpret_rules.rs
+++ b/src/interpret_rules.rs
@@ -7,6 +7,11 @@ use std::collections::HashMap;
 
 type Output = crate::output::OutputRows;
 
+// Experimental execution-cursor VM (#47), a child module so it can reuse this
+// module's private leaf fns via `super::`. Gated behind `NC_VM=1`.
+#[path = "vm.rs"]
+pub(crate) mod vm;
+
 /// Control-flow signal returned by block interpretation: either fall through
 /// to the next block, or a pending GOTO that must be resolved against the
 /// block list of the current scope or, failing that, an enclosing scope

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -270,7 +270,14 @@ fn interpret_file(input: &str, state: &mut State, output: &mut OutputRows) -> Re
         message: "No inner blocks found".to_string(),
     })?;
 
-    match interpret_blocks(blocks, output, state)? {
+    // Experimental: the explicit-stack VM (#47) runs the same structured path
+    // when NC_VM=1, for differential parity against the recursive walker.
+    let flow = if crate::interpret_rules::vm::vm_enabled() {
+        crate::interpret_rules::vm::run(blocks, output, state)?
+    } else {
+        interpret_blocks(blocks, output, state)?
+    };
+    match flow {
         BlockFlow::Continue | BlockFlow::EndProgram => Ok(()),
         // A jump that no scope could resolve: the destination does not exist
         // in the programmed search direction (alarm 14080 on a real control).

--- a/src/output.rs
+++ b/src/output.rs
@@ -378,6 +378,39 @@ impl OutputRows {
         self.flattener = Some(flattener);
     }
 
+    /// Number of committed rows in a `Collect` sink (0 for streaming sinks).
+    /// Lets the experimental resumable VM (#47) pause at a row boundary.
+    #[allow(dead_code)]
+    pub(crate) fn collected_len(&self) -> usize {
+        match &self.sink {
+            RowSink::Collect(rows) => rows.len(),
+            _ => 0,
+        }
+    }
+
+    /// Deep-clone a checkpointable `Collect`-sink output: the committed rows,
+    /// the in-flight row, and the warn latches. `None` when the sink is a
+    /// streaming channel or a flattener is installed (their state isn't
+    /// snapshottable this simply). For the experimental resumable VM (#47);
+    /// the whole-file forward-fill happens later in `Table::from_rows`, so a
+    /// Collect snapshot needs no columnar carry.
+    #[allow(dead_code)]
+    pub(crate) fn snapshot_collect(&self) -> Option<OutputRows> {
+        if self.flattener.is_some() {
+            return None;
+        }
+        match &self.sink {
+            RowSink::Collect(rows) => Some(OutputRows {
+                current: self.current.clone(),
+                sink: RowSink::Collect(rows.clone()),
+                record_variables: self.record_variables,
+                flattener: None,
+                warned_g91: self.warned_g91,
+            }),
+            _ => None,
+        }
+    }
+
     /// Route a finished row to the sink, passing it through the flattener
     /// first when one is installed. Shared by `flush`.
     fn deliver(&mut self, row: Row) -> Result<(), ParsingError> {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -36,7 +36,10 @@ pub(crate) fn vm_enabled() -> bool {
 }
 
 /// One active scope on the reified control stack — the heap equivalent of a
-/// live `interpret_blocks`/`run_blocks` frame.
+/// live `interpret_blocks`/`run_blocks` frame. `Clone` is what makes a
+/// checkpoint cheap: the whole stack snapshots by value (the `Pair`s are index
+/// ranges into the shared, still-alive parse tree).
+#[derive(Clone)]
 struct Frame<'i> {
     /// The scope's block list; `index` is an offset into this (== `run_blocks`'
     /// `block_pairs`). Cloning a `Pair` is cheap (an index range into the tree).
@@ -52,6 +55,7 @@ struct Frame<'i> {
 }
 
 /// What kind of scope a frame is, and the loop state its recursive twin held.
+#[derive(Clone)]
 enum FrameKind<'i> {
     /// The top-level program scope (or an IF branch): no loop-back.
     Straight,
@@ -84,41 +88,81 @@ enum Step<'i> {
     Enter(Box<Frame<'i>>),
 }
 
-/// Drop-in replacement for `interpret_blocks` at the top level: interpret the
-/// program with the explicit-stack VM. Returns `Continue` or `EndProgram`; an
-/// unresolvable jump becomes a `JumpTargetNotFound` error here (the recursive
-/// path returns it up to `interpret_file`, which does the same).
-pub(crate) fn run(blocks: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
-    let root = new_frame(collect_blocks(blocks), FrameKind::Straight, state);
-    let mut stack: Vec<Frame> = vec![root];
+/// The reified interpreter: an explicit control stack that can be stepped,
+/// paused at a row boundary, and cloned. Cloning a `Vm` (plus the `State` and a
+/// `Collect` output snapshot) is a checkpoint; resuming is dropping the clone
+/// back into `step_until`. The `'i` lifetime ties it to the parse tree, which
+/// an in-memory session keeps alive (Phase 1 — see the design doc).
+#[derive(Clone)]
+pub(crate) struct Vm<'i> {
+    stack: Vec<Frame<'i>>,
+}
 
-    while let Some(top) = stack.last() {
-        if top.index >= top.blocks.len() {
-            // End of this scope: loop back, or pop to the enclosing scope.
-            // (Program end is signalled by `Step::EndProgram` in `exec_block`,
-            // never here.)
-            scope_end(&mut stack, output, state)?;
-            continue;
-        }
+/// Why `step_until` returned: the program ended (carrying its terminal
+/// `BlockFlow`), or it paused having reached the requested row budget.
+pub(crate) enum Outcome {
+    Done(BlockFlow),
+    Paused,
+}
 
-        let block = stack.last().unwrap().blocks[stack.last().unwrap().index].clone();
-        match exec_block(block, output, state)? {
-            Step::Continue => stack.last_mut().unwrap().index += 1,
-            Step::EndProgram => {
-                pop_all(&mut stack, state);
-                return Ok(BlockFlow::EndProgram);
+impl<'i> Vm<'i> {
+    /// Start a VM at the top of `blocks` (registers the root scope's jump
+    /// targets with `state`, like `interpret_blocks`).
+    pub(crate) fn new(blocks: Pair<'i, Rule>, state: &mut State) -> Self {
+        let root = new_frame(collect_blocks(blocks), FrameKind::Straight, state);
+        Vm { stack: vec![root] }
+    }
+
+    /// Step the VM until the program ends or (when `stop_at_rows` is `Some(k)`)
+    /// the `Collect` sink has committed at least `k` rows — pausing at a block
+    /// boundary. Resumes cleanly on the next call.
+    pub(crate) fn step_until(
+        &mut self,
+        output: &mut Output,
+        state: &mut State,
+        stop_at_rows: Option<usize>,
+    ) -> Result<Outcome, ParsingError> {
+        while let Some(top) = self.stack.last() {
+            if top.index >= top.blocks.len() {
+                // End of this scope: loop back, or pop to the enclosing scope.
+                // (Program end is `Step::EndProgram` from `exec_block`.)
+                scope_end(&mut self.stack, output, state)?;
+                continue;
             }
-            Step::Enter(frame) => {
-                push_frame(&mut stack, *frame, state);
+
+            let top = self.stack.last().unwrap();
+            let block = top.blocks[top.index].clone();
+            match exec_block(block, output, state)? {
+                Step::Continue => self.stack.last_mut().unwrap().index += 1,
+                Step::EndProgram => {
+                    pop_all(&mut self.stack, state);
+                    return Ok(Outcome::Done(BlockFlow::EndProgram));
+                }
+                Step::Enter(frame) => push_frame(&mut self.stack, *frame, state),
+                Step::Jump(request) => {
+                    resolve_across_stack(&mut self.stack, request, state)?;
+                }
             }
-            Step::Jump(request) => {
-                if !resolve_across_stack(&mut stack, request, state)? {
-                    unreachable!("resolve_across_stack returns Err, not false");
+
+            if let Some(k) = stop_at_rows {
+                if output.collected_len() >= k {
+                    return Ok(Outcome::Paused);
                 }
             }
         }
+        Ok(Outcome::Done(BlockFlow::Continue))
     }
-    Ok(BlockFlow::Continue)
+}
+
+/// Drop-in replacement for `interpret_blocks` at the top level: interpret the
+/// program to completion with the explicit-stack VM. An unresolvable jump
+/// becomes a `JumpTargetNotFound` error (as in the recursive path).
+pub(crate) fn run(blocks: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
+    let mut vm = Vm::new(blocks, state);
+    match vm.step_until(output, state, None)? {
+        Outcome::Done(flow) => Ok(flow),
+        Outcome::Paused => unreachable!("no row budget was set"),
+    }
 }
 
 /// Collect a `blocks` pair's child `block`s into an owned vector of (cheap)
@@ -322,11 +366,11 @@ fn exec_control<'i>(
 ) -> Result<ControlOutcome<'i>, ParsingError> {
     for stmt in control.into_inner() {
         let leaf = match stmt.as_rule() {
-            Rule::while_statement => return Ok(enter_while(stmt, output, state)?),
-            Rule::loop_statement => return Ok(enter_loop(stmt, state)?),
-            Rule::for_statement => return Ok(enter_for(stmt, output, state)?),
-            Rule::repeat_until_statement => return Ok(enter_repeat(stmt, output, state)?),
-            Rule::if_statement => return Ok(enter_if(stmt, output, state)?),
+            Rule::while_statement => return enter_while(stmt, output, state),
+            Rule::loop_statement => return enter_loop(stmt, state),
+            Rule::for_statement => return enter_for(stmt, output, state),
+            Rule::repeat_until_statement => return enter_repeat(stmt, output, state),
+            Rule::if_statement => return enter_if(stmt, output, state),
             // Leaf jumps: reuse the recursive path's leaf fns.
             Rule::goto_statement => interpret_goto(stmt, state)?,
             Rule::if_goto_statement => interpret_if_goto(stmt, state)?,
@@ -497,5 +541,119 @@ fn resolve_across_stack(
         if stack.is_empty() {
             return Err(request.into_not_found_error(state));
         }
+    }
+}
+
+#[cfg(test)]
+mod resume_tests {
+    //! Demonstrates that the reified stack makes checkpoint/resume work: run a
+    //! loop, pause mid-way, snapshot `{Vm, State, Collect output}`, discard the
+    //! originals, and resume purely from the snapshot — producing output
+    //! byte-identical to a straight run. This is the Phase-1 payoff of #47.
+    use super::*;
+    use crate::output::Row;
+    use crate::types::NCParser;
+    use pest::Parser;
+
+    fn axes() -> Vec<String> {
+        ["N", "X", "Y", "Z", "A", "B", "C", "D", "E", "F", "S"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn parse_blocks(input: &str) -> Pair<Rule> {
+        let file = NCParser::parse(Rule::file, input).expect("parse").next().expect("file");
+        file.into_inner().next().expect("blocks")
+    }
+
+    fn fresh_state(input: &str) -> State {
+        let mut s = State::new(axes(), 100_000, None, false);
+        s.set_input(input);
+        s
+    }
+
+    fn run_full(input: &str) -> Vec<Row> {
+        let blocks = parse_blocks(input);
+        let mut state = fresh_state(input);
+        let mut out = Output::collect();
+        let mut vm = Vm::new(blocks, &mut state);
+        vm.step_until(&mut out, &mut state, None).expect("run");
+        out.finish().expect("finish")
+    }
+
+    #[test]
+    fn checkpoint_mid_loop_resumes_to_identical_output() {
+        // 1000 iterations, one output row (`X=R1`) each.
+        let program = "R1=0\nWHILE R1<1000\nX=R1\nR1=R1+1\nENDWHILE\nM30\n";
+
+        // Reference: straight run through the VM.
+        let reference = run_full(program);
+        assert!(reference.len() >= 1000, "expected ~1000 rows, got {}", reference.len());
+
+        // Run until ~500 rows committed, then pause mid-loop.
+        let blocks = parse_blocks(program);
+        let mut state = fresh_state(program);
+        let mut out = Output::collect();
+        let mut vm = Vm::new(blocks, &mut state);
+        let outcome = vm.step_until(&mut out, &mut state, Some(500)).expect("step");
+        assert!(matches!(outcome, Outcome::Paused), "VM should pause at the row budget");
+        let at = out.collected_len();
+        assert!(at >= 500 && at < reference.len(), "paused mid-loop at {at} rows");
+        // We are genuinely mid-loop: the loop counter is partway through.
+        let r1 = state.symbol_table["R1"];
+        assert!(r1 > 0.0 && r1 < 1000.0, "mid-loop counter R1={r1}");
+
+        // ---- checkpoint: clone the whole resumable state ----
+        let ckpt_vm = vm.clone();
+        let ckpt_state = state.clone();
+        let ckpt_out = out.snapshot_collect().expect("Collect snapshot");
+
+        // Prove resume depends ONLY on the checkpoint: drop the originals.
+        drop(vm);
+        drop(state);
+        drop(out);
+
+        // ---- resume purely from the checkpoint, run to completion ----
+        let mut r_vm = ckpt_vm;
+        let mut r_state = ckpt_state;
+        let mut r_out = ckpt_out;
+        r_vm.step_until(&mut r_out, &mut r_state, None).expect("resume");
+        let resumed = r_out.finish().expect("finish");
+
+        // Byte-for-byte identical to the straight run.
+        assert_eq!(resumed.len(), reference.len(), "row count diverged after resume");
+        assert_eq!(
+            format!("{reference:?}"),
+            format!("{resumed:?}"),
+            "resumed output diverged from the straight run"
+        );
+    }
+
+    #[test]
+    fn checkpoint_resume_across_a_backward_jump_loop() {
+        // Same shape but built from a GOTOB loop (exercises the jump stack, not
+        // a structured WHILE): N10 counts up, GOTOB back to the label.
+        let program = "R1=0\n\
+             LOOP_TOP: X=R1\n\
+             R1=R1+1\n\
+             IF R1<800 GOTOB LOOP_TOP\n\
+             M30\n";
+        let reference = run_full(program);
+        assert!(reference.len() >= 800);
+
+        let blocks = parse_blocks(program);
+        let mut state = fresh_state(program);
+        let mut out = Output::collect();
+        let mut vm = Vm::new(blocks, &mut state);
+        vm.step_until(&mut out, &mut state, Some(400)).expect("step");
+
+        let mut r_vm = vm.clone();
+        let mut r_state = state.clone();
+        let mut r_out = out.snapshot_collect().expect("snapshot");
+        r_vm.step_until(&mut r_out, &mut r_state, None).expect("resume");
+        let resumed = r_out.finish().expect("finish");
+
+        assert_eq!(format!("{reference:?}"), format!("{resumed:?}"));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,501 @@
+//! Experimental execution-cursor VM for the structured interpreter path (#47).
+//!
+//! This is a **behaviour-preserving reification** of the recursive block walker
+//! in the parent module: `run_blocks` plus the recursive
+//! `interpret_statement_while/for/loop/repeat/if` calls are replaced by an
+//! explicit `Vec<Frame>` work-stack driven by a single loop. Each `Frame`
+//! mirrors exactly what one recursive `interpret_blocks` invocation held on the
+//! Rust stack (its block list, jump-target map, cursor `index`, backward-jump
+//! counter, and — for a loop — its `loop_count` and cached bound/condition).
+//!
+//! Every *leaf* operation (statements, assignments, expressions, conditions,
+//! frame ops, the GOTO family, M-code end detection) is reused verbatim from
+//! the parent module via `super::` — the VM only owns *control flow*.
+//!
+//! Why: an explicit stack is serializable (a `pc` + owned frames), which is the
+//! "execution cursor" that makes seek-by-checkpoint cheap
+//! (docs/resumable-interpretation-design.md). Gated behind `NC_VM=1` so it runs
+//! beside the recursive path and can be diffed against it on the golden corpus.
+
+use super::{
+    evaluate_condition, evaluate_expression, get_error_context, interpret_assignment, interpret_block_number,
+    interpret_case, interpret_definition, interpret_frame_op, interpret_goto, interpret_if_goto, interpret_statement,
+    resolve_jump, scan_jump_targets, BlockFlow,
+};
+use crate::errors::ParsingError;
+use crate::output::OutputRows as Output;
+use crate::state::State;
+use crate::types::{Rule, Value};
+use pest::iterators::Pair;
+use std::collections::HashMap;
+
+/// True when `NC_VM=1` selects the experimental cursor VM over the recursive
+/// walker for the structured path.
+pub(crate) fn vm_enabled() -> bool {
+    std::env::var("NC_VM").map(|v| v == "1").unwrap_or(false)
+}
+
+/// One active scope on the reified control stack — the heap equivalent of a
+/// live `interpret_blocks`/`run_blocks` frame.
+struct Frame<'i> {
+    /// The scope's block list; `index` is an offset into this (== `run_blocks`'
+    /// `block_pairs`). Cloning a `Pair` is cheap (an index range into the tree).
+    blocks: Vec<Pair<'i, Rule>>,
+    /// Label / block-number → ascending block indices, for jump resolution.
+    targets: HashMap<String, Vec<usize>>,
+    /// The instruction pointer within this scope.
+    index: usize,
+    /// Backward-jump cycle counter (bounded by `iteration_limit`), per scope —
+    /// mirrors `run_blocks`' local `jumps_taken`.
+    jumps_taken: usize,
+    kind: FrameKind<'i>,
+}
+
+/// What kind of scope a frame is, and the loop state its recursive twin held.
+enum FrameKind<'i> {
+    /// The top-level program scope (or an IF branch): no loop-back.
+    Straight,
+    While {
+        cond: Pair<'i, Rule>,
+        count: usize,
+    },
+    Loop {
+        count: usize,
+    },
+    Repeat {
+        cond: Pair<'i, Rule>,
+        count: usize,
+    },
+    For {
+        var: String,
+        end: f64,
+    },
+}
+
+/// What executing one block asked the driver to do next.
+enum Step<'i> {
+    /// Advance to the next block in the current scope.
+    Continue,
+    /// M2/M17/M30 executed — end interpretation.
+    EndProgram,
+    /// A pending GOTO to resolve against the scope stack.
+    Jump(super::JumpRequest),
+    /// A structured control opened a body scope; push this frame.
+    Enter(Box<Frame<'i>>),
+}
+
+/// Drop-in replacement for `interpret_blocks` at the top level: interpret the
+/// program with the explicit-stack VM. Returns `Continue` or `EndProgram`; an
+/// unresolvable jump becomes a `JumpTargetNotFound` error here (the recursive
+/// path returns it up to `interpret_file`, which does the same).
+pub(crate) fn run(blocks: Pair<Rule>, output: &mut Output, state: &mut State) -> Result<BlockFlow, ParsingError> {
+    let root = new_frame(collect_blocks(blocks), FrameKind::Straight, state);
+    let mut stack: Vec<Frame> = vec![root];
+
+    while let Some(top) = stack.last() {
+        if top.index >= top.blocks.len() {
+            // End of this scope: loop back, or pop to the enclosing scope.
+            // (Program end is signalled by `Step::EndProgram` in `exec_block`,
+            // never here.)
+            scope_end(&mut stack, output, state)?;
+            continue;
+        }
+
+        let block = stack.last().unwrap().blocks[stack.last().unwrap().index].clone();
+        match exec_block(block, output, state)? {
+            Step::Continue => stack.last_mut().unwrap().index += 1,
+            Step::EndProgram => {
+                pop_all(&mut stack, state);
+                return Ok(BlockFlow::EndProgram);
+            }
+            Step::Enter(frame) => {
+                push_frame(&mut stack, *frame, state);
+            }
+            Step::Jump(request) => {
+                if !resolve_across_stack(&mut stack, request, state)? {
+                    unreachable!("resolve_across_stack returns Err, not false");
+                }
+            }
+        }
+    }
+    Ok(BlockFlow::Continue)
+}
+
+/// Collect a `blocks` pair's child `block`s into an owned vector of (cheap)
+/// pair handles.
+fn collect_blocks(blocks: Pair<Rule>) -> Vec<Pair<Rule>> {
+    blocks.into_inner().collect()
+}
+
+/// Build a frame and register its jump targets with `State` (mirrors
+/// `interpret_blocks`' `seen_jump_targets.extend` + `jump_scopes.push`).
+fn new_frame<'i>(blocks: Vec<Pair<'i, Rule>>, kind: FrameKind<'i>, state: &mut State) -> Frame<'i> {
+    let targets = scan_jump_targets(&blocks);
+    state.seen_jump_targets.extend(targets.keys().cloned());
+    state.jump_scopes.push(targets.keys().cloned().collect());
+    Frame {
+        blocks,
+        targets,
+        index: 0,
+        jumps_taken: 0,
+        kind,
+    }
+}
+
+fn push_frame<'i>(stack: &mut Vec<Frame<'i>>, frame: Frame<'i>, _state: &mut State) {
+    // jump_scopes was already pushed by new_frame(); just move the frame in.
+    stack.push(frame);
+}
+
+/// Pop a frame and unwind its `jump_scopes` entry. Used on jump propagation
+/// (the enclosing scope will resolve at *its* current index, so no advance).
+fn pop_frame(stack: &mut Vec<Frame>, state: &mut State) {
+    stack.pop();
+    state.jump_scopes.pop();
+}
+
+/// Pop a scope that completed normally, then advance the enclosing scope past
+/// the control block that spawned it — the recursive walker does this when
+/// `interpret_block(control_block)` returns `Continue` and `run_blocks` does
+/// `index += 1`. Without the advance the parent re-executes the control forever.
+fn pop_and_advance(stack: &mut Vec<Frame>, state: &mut State) {
+    pop_frame(stack, state);
+    if let Some(parent) = stack.last_mut() {
+        parent.index += 1;
+    }
+}
+
+fn pop_all(stack: &mut Vec<Frame>, state: &mut State) {
+    while !stack.is_empty() {
+        pop_frame(stack, state);
+    }
+}
+
+/// Handle reaching the end of the top scope's block list: for a loop, re-test
+/// and either restart the body (reset `index`) or pop; for a straight scope,
+/// pop. Mirrors the `while`/`loop` tails of the recursive statement fns.
+fn scope_end(stack: &mut Vec<Frame>, output: &mut Output, state: &mut State) -> Result<(), ParsingError> {
+    // We need the loop kind/state; take it out to avoid borrow conflicts.
+    let top = stack.last_mut().expect("scope_end called with a frame");
+    match &mut top.kind {
+        FrameKind::Straight => {
+            pop_and_advance(stack, state);
+        }
+        FrameKind::While { cond, count } => {
+            let cond = cond.clone();
+            // `while eval() && count < limit { count += 1; body }` then
+            // `if count >= limit { Err }`. Re-test to decide restart vs exit.
+            if evaluate_condition(cond, state)? && *count < state.iteration_limit {
+                let top = stack.last_mut().unwrap();
+                if let FrameKind::While { count, .. } = &mut top.kind {
+                    *count += 1;
+                }
+                top.index = 0;
+            } else {
+                let hit_limit = *count >= state.iteration_limit;
+                pop_and_advance(stack, state);
+                if hit_limit {
+                    return Err(ParsingError::LoopLimit {
+                        limit: state.iteration_limit.to_string(),
+                    });
+                }
+            }
+        }
+        FrameKind::Loop { count } => {
+            // `loop { body; count += 1; if count >= limit { Err } }`.
+            *count += 1;
+            if *count >= state.iteration_limit {
+                let limit = state.iteration_limit.to_string();
+                pop_and_advance(stack, state);
+                return Err(ParsingError::LoopLimit { limit });
+            }
+            top.index = 0;
+        }
+        FrameKind::Repeat { cond, count } => {
+            // `loop { body; count += 1; if count >= limit { Err }; if eval() { break } }`.
+            *count += 1;
+            if *count >= state.iteration_limit {
+                let limit = state.iteration_limit.to_string();
+                pop_and_advance(stack, state);
+                return Err(ParsingError::LoopLimit { limit });
+            }
+            let cond = cond.clone();
+            if evaluate_condition(cond, state)? {
+                pop_and_advance(stack, state);
+            } else {
+                stack.last_mut().unwrap().index = 0;
+            }
+        }
+        FrameKind::For { var, end } => {
+            // `while symbol[var] <= end { body; symbol[var] += 1; record }`.
+            let var = var.clone();
+            let end = *end;
+            let new_value = {
+                let v = state.symbol_table.get_mut(&var).expect("FOR counter exists");
+                *v += 1.0;
+                *v
+            };
+            output.record_variable_change(&var, new_value);
+            if new_value <= end {
+                stack.last_mut().unwrap().index = 0;
+            } else {
+                pop_and_advance(stack, state);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Execute one block, mirroring `interpret_block`: start its output row, then
+/// process each item. A structured control (`WHILE/FOR/LOOP/REPEAT/IF`) yields
+/// `Step::Enter` instead of recursing; leaf jumps (`GOTO*`, `IF..GOTO`, `CASE`)
+/// go through the reused leaf fns and yield their `BlockFlow`.
+fn exec_block<'i>(block: Pair<'i, Rule>, output: &mut Output, state: &mut State) -> Result<Step<'i>, ParsingError> {
+    if block.as_rule() != Rule::block {
+        return Err(ParsingError::UnexpectedRule {
+            rule: block.as_rule(),
+            context: "vm::exec_block".to_string(),
+            line_no: block.line_col().0,
+            preview: state.get_line(block.line_col().0).unwrap_or("").to_string(),
+            message: format!("Expected a block, found {:?}", block.as_rule()),
+        });
+    }
+    output.start_row(block.line_col().0)?;
+
+    // Mirror `interpret_block`: process EVERY item, letting the control-flow
+    // signal accumulate (last write wins, like `flow = interpret_control(...)`),
+    // and return it only at the end — so a trailing `; comment` on a GOTO line
+    // still lands on the row. A *structured* control opens a body scope and must
+    // suspend block processing, so it returns `Enter` immediately.
+    let mut flow = BlockFlow::Continue;
+    for item in block.into_inner() {
+        match item.as_rule() {
+            Rule::statement => {
+                if let BlockFlow::EndProgram = interpret_statement(item, output, state)? {
+                    flow = BlockFlow::EndProgram;
+                }
+            }
+            Rule::block_number => interpret_block_number(item, output),
+            Rule::label_def => {}
+            Rule::definition => interpret_definition(item, output, state)?,
+            Rule::frame_op => interpret_frame_op(item, state)?,
+            Rule::comment => {
+                let last = output.last_mut().expect("row started");
+                last.insert("comment", Value::Str(item.as_str().to_string()));
+            }
+            Rule::control => match exec_control(item, output, state)? {
+                ControlOutcome::Enter(frame) => return Ok(Step::Enter(frame)),
+                ControlOutcome::Flow(f) => flow = f,
+            },
+            other => {
+                return Err(ParsingError::UnexpectedRule {
+                    rule: other,
+                    context: "vm::exec_block".to_string(),
+                    line_no: 0,
+                    preview: String::new(),
+                    message: format!("Unexpected rule in block: {other:?}"),
+                })
+            }
+        }
+    }
+    Ok(match flow {
+        BlockFlow::Continue => Step::Continue,
+        BlockFlow::EndProgram => Step::EndProgram,
+        BlockFlow::Jump(r) => Step::Jump(r),
+    })
+}
+
+/// The result of a `control` node: either a structured body to enter, or a
+/// leaf control-flow signal (from a GOTO family / CASE / GOTOS) to accumulate.
+enum ControlOutcome<'i> {
+    Enter(Box<Frame<'i>>),
+    Flow(BlockFlow),
+}
+
+/// Handle a `control` node, mirroring `interpret_control`: a structured control
+/// yields `Enter`; leaf jumps run through the reused leaf fns with the first
+/// non-`Continue` winning.
+fn exec_control<'i>(
+    control: Pair<'i, Rule>,
+    output: &mut Output,
+    state: &mut State,
+) -> Result<ControlOutcome<'i>, ParsingError> {
+    for stmt in control.into_inner() {
+        let leaf = match stmt.as_rule() {
+            Rule::while_statement => return Ok(enter_while(stmt, output, state)?),
+            Rule::loop_statement => return Ok(enter_loop(stmt, state)?),
+            Rule::for_statement => return Ok(enter_for(stmt, output, state)?),
+            Rule::repeat_until_statement => return Ok(enter_repeat(stmt, output, state)?),
+            Rule::if_statement => return Ok(enter_if(stmt, output, state)?),
+            // Leaf jumps: reuse the recursive path's leaf fns.
+            Rule::goto_statement => interpret_goto(stmt, state)?,
+            Rule::if_goto_statement => interpret_if_goto(stmt, state)?,
+            Rule::case_statement => interpret_case(stmt, state)?,
+            Rule::gotos_statement => {
+                let (line_no, _) = get_error_context(&stmt, state);
+                crate::state::emit_warning(format_args!(
+                    "Warning: GOTOS ignored (line {}): the program restart depends on the PLC signal enableGoToStart; continuing with the next block",
+                    line_no
+                ));
+                BlockFlow::Continue
+            }
+            other => {
+                return Err(ParsingError::UnexpectedRule {
+                    rule: other,
+                    context: "vm::exec_control".to_string(),
+                    line_no: 0,
+                    preview: String::new(),
+                    message: format!("Unexpected control rule: {other:?}"),
+                })
+            }
+        };
+        // First non-Continue leaf jump wins (matches interpret_control).
+        if !matches!(leaf, BlockFlow::Continue) {
+            return Ok(ControlOutcome::Flow(leaf));
+        }
+    }
+    Ok(ControlOutcome::Flow(BlockFlow::Continue))
+}
+
+/// `WHILE cond ... ENDWHILE`: test once; enter the body scope iff it passes.
+fn enter_while<'i>(
+    stmt: Pair<'i, Rule>,
+    _output: &mut Output,
+    state: &mut State,
+) -> Result<ControlOutcome<'i>, ParsingError> {
+    let mut pairs = stmt.into_inner();
+    let cond = pairs.next().expect("while: condition");
+    let body = pairs.next().expect("while: body blocks");
+    if evaluate_condition(cond.clone(), state)? && 0 < state.iteration_limit {
+        let frame = new_frame(collect_blocks(body), FrameKind::While { cond, count: 1 }, state);
+        Ok(ControlOutcome::Enter(Box::new(frame)))
+    } else {
+        Ok(ControlOutcome::Flow(BlockFlow::Continue))
+    }
+}
+
+/// `LOOP ... ENDLOOP`: unconditional; always enter the body (guarded by the
+/// iteration limit at each back-edge).
+fn enter_loop<'i>(stmt: Pair<'i, Rule>, state: &mut State) -> Result<ControlOutcome<'i>, ParsingError> {
+    let body = stmt.into_inner().next().expect("loop: body blocks");
+    let frame = new_frame(collect_blocks(body), FrameKind::Loop { count: 0 }, state);
+    Ok(ControlOutcome::Enter(Box::new(frame)))
+}
+
+/// `FOR var = a TO b ... ENDFOR`: init the counter, evaluate the bound, enter
+/// the body iff `counter <= bound`.
+fn enter_for<'i>(
+    stmt: Pair<'i, Rule>,
+    output: &mut Output,
+    state: &mut State,
+) -> Result<ControlOutcome<'i>, ParsingError> {
+    let mut pairs = stmt.into_inner();
+    let assignment = pairs.next().expect("for: assignment");
+    let (assign_line_no, assign_preview) = get_error_context(&assignment, state);
+    let (var, initial) = interpret_assignment(assignment, state)?;
+    let Some(initial) = initial else {
+        return Err(ParsingError::with_context(
+            assign_line_no,
+            assign_preview,
+            "FOR statement".to_string(),
+            format!("FOR counter '{var}' cannot be initialized with a string"),
+        ));
+    };
+    output.record_variable_change(&var, initial);
+    let to_expr = pairs.next().expect("for: TO expression");
+    let end = evaluate_expression(to_expr, state)?;
+    let body = pairs.next().expect("for: body blocks");
+
+    let current = *state.symbol_table.get(&var).expect("FOR counter set");
+    if current <= end {
+        let frame = new_frame(collect_blocks(body), FrameKind::For { var, end }, state);
+        Ok(ControlOutcome::Enter(Box::new(frame)))
+    } else {
+        Ok(ControlOutcome::Flow(BlockFlow::Continue))
+    }
+}
+
+/// `REPEAT ... UNTIL cond`: body-first; always enter the body once.
+fn enter_repeat<'i>(
+    stmt: Pair<'i, Rule>,
+    output: &mut Output,
+    state: &mut State,
+) -> Result<ControlOutcome<'i>, ParsingError> {
+    let mut pairs = stmt.into_inner();
+    let first = pairs.next().expect("repeat: first pair");
+    let (body, cond) = if first.as_rule() == Rule::comment {
+        let last = output.last_mut().expect("row started");
+        last.insert("comment", Value::Str(first.as_str().to_string()));
+        let body = pairs.next().expect("repeat: body blocks");
+        let cond = pairs.next().expect("repeat: condition");
+        (body, cond)
+    } else {
+        let cond = pairs.next().expect("repeat: condition");
+        (first, cond)
+    };
+    let frame = new_frame(collect_blocks(body), FrameKind::Repeat { cond, count: 0 }, state);
+    Ok(ControlOutcome::Enter(Box::new(frame)))
+}
+
+/// `IF cond ... [ELSE ...] ENDIF`: enter the taken branch as a straight scope.
+fn enter_if<'i>(
+    stmt: Pair<'i, Rule>,
+    output: &mut Output,
+    state: &mut State,
+) -> Result<ControlOutcome<'i>, ParsingError> {
+    let mut pairs = stmt.into_inner();
+    let condition = pairs.next().expect("if: condition");
+    // Optional comment between the condition and the true block.
+    let mut next = pairs.next().expect("if: true block or comment");
+    if next.as_rule() == Rule::comment {
+        let last = output.last_mut().expect("row started");
+        last.insert("comment", Value::Str(next.as_str().to_string()));
+        next = pairs.next().expect("if: true block");
+    }
+    let true_block = next;
+    let false_block = pairs.next();
+
+    let taken = if evaluate_condition(condition, state)? {
+        Some(true_block)
+    } else {
+        false_block
+    };
+    match taken {
+        Some(blocks) => {
+            let frame = new_frame(collect_blocks(blocks), FrameKind::Straight, state);
+            Ok(ControlOutcome::Enter(Box::new(frame)))
+        }
+        None => Ok(ControlOutcome::Flow(BlockFlow::Continue)),
+    }
+}
+
+/// Resolve a pending jump against the scope stack, innermost first: on a hit,
+/// set that scope's cursor (bounding backward jumps by the iteration limit) and
+/// discard the inner scopes it jumped out of; on a miss, pop the scope and retry
+/// in the enclosing one. Always resolves or errors (never returns `false`).
+fn resolve_across_stack(
+    stack: &mut Vec<Frame>,
+    request: super::JumpRequest,
+    state: &mut State,
+) -> Result<bool, ParsingError> {
+    loop {
+        let top = stack.last_mut().expect("stack non-empty during jump");
+        if let Some(dest) = resolve_jump(&top.targets, top.index, &request) {
+            if dest <= top.index {
+                top.jumps_taken += 1;
+                if top.jumps_taken >= state.iteration_limit {
+                    return Err(ParsingError::LoopLimit {
+                        limit: state.iteration_limit.to_string(),
+                    });
+                }
+            }
+            top.index = dest;
+            return Ok(true);
+        }
+        // Not resolvable here: leave this scope and try the enclosing one.
+        pop_frame(stack, state);
+        if stack.is_empty() {
+            return Err(request.into_not_found_error(state));
+        }
+    }
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -332,13 +332,14 @@ fn exec_block<'i>(block: Pair<'i, Rule>, output: &mut Output, state: &mut State)
                 ControlOutcome::Flow(f) => flow = f,
             },
             other => {
+                let (line_no, preview) = get_error_context(&item, state);
                 return Err(ParsingError::UnexpectedRule {
                     rule: other,
                     context: "vm::exec_block".to_string(),
-                    line_no: 0,
-                    preview: String::new(),
+                    line_no,
+                    preview,
                     message: format!("Unexpected rule in block: {other:?}"),
-                })
+                });
             }
         }
     }
@@ -384,13 +385,14 @@ fn exec_control<'i>(
                 BlockFlow::Continue
             }
             other => {
+                let (line_no, preview) = get_error_context(&stmt, state);
                 return Err(ParsingError::UnexpectedRule {
                     rule: other,
                     context: "vm::exec_control".to_string(),
-                    line_no: 0,
-                    preview: String::new(),
+                    line_no,
+                    preview,
                     message: format!("Unexpected control rule: {other:?}"),
-                })
+                });
             }
         };
         // First non-Continue leaf jump wins (matches interpret_control).
@@ -516,12 +518,12 @@ fn enter_if<'i>(
 /// Resolve a pending jump against the scope stack, innermost first: on a hit,
 /// set that scope's cursor (bounding backward jumps by the iteration limit) and
 /// discard the inner scopes it jumped out of; on a miss, pop the scope and retry
-/// in the enclosing one. Always resolves or errors (never returns `false`).
+/// in the enclosing one. Always resolves or errors.
 fn resolve_across_stack(
     stack: &mut Vec<Frame>,
     request: super::JumpRequest,
     state: &mut State,
-) -> Result<bool, ParsingError> {
+) -> Result<(), ParsingError> {
     loop {
         let top = stack.last_mut().expect("stack non-empty during jump");
         if let Some(dest) = resolve_jump(&top.targets, top.index, &request) {
@@ -534,7 +536,7 @@ fn resolve_across_stack(
                 }
             }
             top.index = dest;
-            return Ok(true);
+            return Ok(());
         }
         // Not resolvable here: leave this scope and try the enclosing one.
         pop_frame(stack, state);


### PR DESCRIPTION
Foundation for resumable interpretation (#47), following the design in `docs/resumable-interpretation-design.md` (approach *b*). **Opt-in and additive** — the recursive interpreter stays the default; nothing changes unless `NC_VM=1` is set.

## What
Reify the recursive structured walker (`run_blocks` + `interpret_statement_while/for/loop/repeat/if`) into an explicit `Vec<Frame>` work-stack VM (`src/vm.rs`) — the "execution cursor" the streaming roadmap and #47 both need. Each frame mirrors exactly what one recursive `interpret_blocks` call held on the Rust stack (block list, jump-target map, cursor `index`, backward-jump counter, loop state). Every leaf op (statements, expressions, conditions, frame ops, GOTO family) is **reused verbatim** from `interpret_rules` via `super::`; the VM owns only control flow. It's a `#[path]` child module, so there are **zero changes to existing code visibility**.

On top of the (now `Clone`-able, steppable) stack: `Vm::step_until(output, state, stop_at_rows)` pauses at a row boundary, and a checkpoint is `clone(Vm stack + State + Collect output snapshot)` — resume is `step_until` on the clone.

## Why opt-in (for now)
This lands the validated machinery and de-risks #47 without swapping out the interpreter. Promoting the VM to the default (and deleting the recursive path), and exposing a public `NcSession` checkpoint/resume API, are deliberate follow-ups (Phases 2–3 in the design doc) — kept out of this PR to keep it small and reviewable.

## Validation
- **Byte-identical to the recursive interpreter across the whole corpus** under `NC_VM=1` — 60 Rust lib tests + 327 pytest (golden `test_expected_output` + the mill-sim `test_stage1` differential, incl. the `goto.mpf` jump torture test). CI green.
- **Two checkpoint/resume tests**: run a 1000-iteration loop, pause mid-way, snapshot, **drop the originals**, and resume purely from the snapshot to identical output — for a structured `WHILE` and a `GOTOB` backward-jump loop.
- **Performance-neutral**: 3M-iteration loop → dataframe, VM ~8.4s vs recursive ~8.7s (within noise). No effect on structure-free CAM files (they take the stage-1 line-driver, which neither path touches).

## Two bugs the corpus caught during bring-up
- A parent scope must advance past a control block only when its child completes *normally* — not on jump-propagation (which resolves at the control block's own index).
- A block must process all items *after* a leaf GOTO (the trailing `; comment`), matching `interpret_block`.

## Follow-ups (not in this PR)
- Serializable checkpoint token (survive process restart) — Phase 2.
- Lazy per-line parse / O(1) start — Phase 3, the streaming payoff.
- Public `NcSession` API + promoting the VM to default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)